### PR TITLE
Do not enlarge images smaller than 800px [CarrierWave]

### DIFF
--- a/lib/generators/ckeditor/templates/models/base/carrierwave/uploaders/ckeditor_picture_uploader.rb
+++ b/lib/generators/ckeditor/templates/models/base/carrierwave/uploaders/ckeditor_picture_uploader.rb
@@ -36,7 +36,7 @@ class CkeditorPictureUploader < CarrierWave::Uploader::Base
   end
 
   version :content do
-    process :resize_to_fit => [800, 800]
+    process :resize_to_limit => [800, 800]
   end
 
   # Add a white list of extensions which are allowed to be uploaded.


### PR DESCRIPTION
Prevent ckeditor from enlarging pictures that are smaller than 800px.
