### PR TITLE
Add missing rescue

### DIFF
--- a/lib/generators/ckeditor/templates/models/active_record/carrierwave/ckeditor/attachment_file.rb
+++ b/lib/generators/ckeditor/templates/models/active_record/carrierwave/ckeditor/attachment_file.rb
@@ -6,6 +6,7 @@ class Ckeditor::AttachmentFile < Ckeditor::Asset
 	    extname = File.extname(filename).gsub(/^\./, '')
       "/javascripts/ckeditor/filebrowser/images/thumbs/#{extname}.gif"
     rescue
+      '/javascripts/ckeditor/filebrowser/images/thumbs/ckfnothumb.gif'
 	  end
 	end
 end

--- a/lib/generators/ckeditor/templates/models/active_record/paperclip/ckeditor/attachment_file.rb
+++ b/lib/generators/ckeditor/templates/models/active_record/paperclip/ckeditor/attachment_file.rb
@@ -11,6 +11,7 @@ class Ckeditor::AttachmentFile < Ckeditor::Asset
 	    extname = File.extname(filename).gsub(/^\./, '')
       "/javascripts/ckeditor/filebrowser/images/thumbs/#{extname}.gif"
     rescue
+      '/javascripts/ckeditor/filebrowser/images/thumbs/ckfnothumb.gif'
 	  end
 	end
 end

--- a/lib/generators/ckeditor/templates/models/mongoid/carrierwave/ckeditor/attachment_file.rb
+++ b/lib/generators/ckeditor/templates/models/mongoid/carrierwave/ckeditor/attachment_file.rb
@@ -6,6 +6,7 @@ class Ckeditor::AttachmentFile < Ckeditor::Asset
 	    extname = File.extname(filename).gsub(/^\./, '')
       "/javascripts/ckeditor/filebrowser/images/thumbs/#{extname}.gif"
     rescue
+      '/javascripts/ckeditor/filebrowser/images/thumbs/ckfnothumb.gif'
 	  end
 	end
 end

--- a/lib/generators/ckeditor/templates/models/mongoid/paperclip/ckeditor/attachment_file.rb
+++ b/lib/generators/ckeditor/templates/models/mongoid/paperclip/ckeditor/attachment_file.rb
@@ -11,6 +11,7 @@ class Ckeditor::AttachmentFile < Ckeditor::Asset
       extname = File.extname(filename).gsub(/^\./, '')
       "/javascripts/ckeditor/filebrowser/images/thumbs/#{extname}.gif"
     rescue
+      '/javascripts/ckeditor/filebrowser/images/thumbs/ckfnothumb.gif'
     end
   end
 end


### PR DESCRIPTION
Hi!

This helps, if you try to upload a pdf or zip file. I think you simply forgotten to add 'rescue' word and it crashes.
