### PR TITLE
Change util's applay_options function to wrap object keys in quote

### DIFF
--- a/lib/ckeditor/utils.rb
+++ b/lib/ckeditor/utils.rb
@@ -66,7 +66,7 @@ module Ckeditor
             else value
           end
           
-          str << "#{key}: #{item}"
+          str << %Q{"#{key}": #{item}}
         end
         
         str.sort.join(',')

--- a/test/integration/posts_test.rb
+++ b/test/integration/posts_test.rb
@@ -13,23 +13,23 @@ class PostsTest < ActiveSupport::IntegrationCase
     visit(posts_path)
     
     assert page.body.include?('/javascripts/ckeditor/ckeditor.js')
-    assert page.body.include?("CKEDITOR.replace('test_area', { language: 'en' });")
+    assert page.body.include?(%q{CKEDITOR.replace('test_area', { "language": 'en' });})
   end
   
   test "pass text_area with options" do
     visit(posts_path)
     
     assert page.body.include?('<textarea cols="10" id="content" name="content" rows="20">Ckeditor</textarea>')
-    assert page.body.include?("CKEDITOR.replace('content', { language: 'en',toolbar: 'Easy' });")
+    assert page.body.include?(%q{CKEDITOR.replace('content', { "language": 'en',"toolbar": 'Easy' });})
   end
   
   test "form builder helper" do
     visit(new_post_path)
     
     assert page.body.include?('<textarea cols="40" id="post_content" name="post[content]" rows="20"></textarea>')
-    assert page.body.include?("CKEDITOR.replace('post_content', { height: 400,language: 'en',width: 800 });")
+    assert page.body.include?(%q{CKEDITOR.replace('post_content', { "height": 400,"language": 'en',"width": 800 });})
     assert page.body.include?('<textarea cols="40" id="post_info" name="post[info]" rows="20">Defaults info content</textarea>')
-    assert page.body.include?("CKEDITOR.replace('post_info', { language: 'en' });")
+    assert page.body.include?(%q{CKEDITOR.replace('post_info', { "language": 'en' });})
   end
   
   test "text_area value" do


### PR DESCRIPTION
Fixes possible errors with reserved identifier in some browsers
such as _class_ in IE (actually, simple_form sends a _class_ key by
default in IE)
