### PR TITLE
Changed asset.size to asset.data_file_size

### DIFF
--- a/app/views/ckeditor/shared/_asset.html.erb
+++ b/app/views/ckeditor/shared/_asset.html.erb
@@ -13,7 +13,7 @@
 			<div class="img-name"><%= asset.filename %></div>
 			<div class="time-size">
 				<div class="time"><%= asset.format_created_at %></div>
-				<div class="fileupload-size size"><%= number_to_human_size(asset.size) %></div>
+				<div class="fileupload-size size"><%= number_to_human_size(asset.data_file_size) %></div>
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
My app kept on crashing on Heroku while trying to view the uploaded files when there were multiple assets and I noticed it was slowing down linearly with the amount of them. Tracked it down to in _asset.hml.erb.
