### PR TITLE
Ignore nil values to avoid javascript errors

### DIFF
--- a/lib/ckeditor/utils.rb
+++ b/lib/ckeditor/utils.rb
@@ -14,7 +14,7 @@ module Ckeditor
       end
       
       def js_replace(dom_id, options = {})
-        js_options = applay_options(options)
+        js_options = applay_options(options.reject{|k,v| v.nil?})
         js = ["if (CKEDITOR.instances['#{dom_id}']) {CKEDITOR.remove(CKEDITOR.instances['#{dom_id}']);}"]
         
         if js_options.blank?


### PR DESCRIPTION
When using fields_for o simple_fields_for somethimes you get an empty namespace key
that breaks the script.

Im my case I was receiving an empty namespace key in the options and the result json was : 

<pre>
{ .... , 'namespace': }
</pre>


And then the ckedtor never load in the text area because json syntax is incorrect.
