### PR TITLE
Fix assets not compiling with initialize_on_precompile = false

### DIFF
--- a/lib/ckeditor/engine.rb
+++ b/lib/ckeditor/engine.rb
@@ -7,7 +7,7 @@ module Ckeditor
     
     config.action_view.javascript_expansions[:ckeditor] = "ckeditor/ckeditor"
     
-    initializer "ckeditor.assets_precompile" do |app|
+    initializer "ckeditor.assets_precompile", :group => :assets do |app|
       app.config.assets.precompile += Ckeditor.assets
     end
     


### PR DESCRIPTION
Currently, if you set config.assets.initialize_on_precompile = false in application.rb (e.g. when deploying to Heroku), the ckeditor.js and other asset files don't get precompiled.

This fix adds :group => :assets to the initializer hook, so that Rails knows to run it even when the application isn't initialized. This was mentioned in the Rails 3.1.1 release notes:

"Plugins developers need to special case their initializers that are meant to be run in the assets group by adding :group => :assets. [José Valim]"
http://weblog.rubyonrails.org/2011/10/7/ann-rails-3-1-1/

Long story short, it means everything will work nicely if you set config.assets.initialize_on_precompile = false, without any extra configuration needed :)
