### PR TITLE
Fixing assets src url.

### DIFF
--- a/app/views/ckeditor/shared/_asset.html.erb
+++ b/app/views/ckeditor/shared/_asset.html.erb
@@ -1,7 +1,7 @@
-<%= content_tag(:div, :id => dom_id(asset), :class => "gal-item", :"data-url" => asset.url_content) do %>
-  <%= link_to image_tag("/assets/ckeditor/filebrowser/images/gal_del.png", 
-    :title => I18n.t('ckeditor.buttons.delete')), 
-          polymorphic_path(asset, :format => :json), 
+<%= content_tag(:div, :id => dom_id(asset), :class => "gal-item", :"data-url" => image_path(asset.url_content)) do %>
+  <%= link_to image_tag("/assets/ckeditor/filebrowser/images/gal_del.png",
+    :title => I18n.t('ckeditor.buttons.delete')),
+          polymorphic_path(asset, :format => :json),
           :remote => true,
           :method => :delete, 
           :confirm => t('ckeditor.confirm_delete'),


### PR DESCRIPTION
Hi,
I made a small change in a view to properly use `image_path` to generate the asset url. We must do it because if someone would set the asset host configuration (`config.action_controller.asset_host = "http://assets.mysite.com"`) in the environment the previous code would note use it.
