### PR TITLE
Updated init.js to allow for sub directory Rails apps

### DIFF
--- a/app/assets/javascripts/ckeditor/init.js.erb
+++ b/app/assets/javascripts/ckeditor/init.js.erb
@@ -3,6 +3,6 @@
 
 (function() {
   if (typeof window['CKEDITOR_BASEPATH'] === "undefined" || window['CKEDITOR_BASEPATH'] === null) {
-    window['CKEDITOR_BASEPATH'] = "/assets/ckeditor/";
+    window['CKEDITOR_BASEPATH'] = "<%= config.relative_url_root %>/assets/ckeditor/";
   }
 }).call(this);


### PR DESCRIPTION
I've just added a small change in init.js (and renamed it to init.js.erb) to allow for Rails apps that are in subdirectories to correctly include the CKEditor javascript assets by setting config.relative_url_root
