### PR TITLE
Fix bug with filename not being shown w/ mongoid and carrierwave

### DIFF
--- a/lib/generators/ckeditor/templates/base/carrierwave/uploaders/ckeditor_attachment_file_uploader.rb
+++ b/lib/generators/ckeditor/templates/base/carrierwave/uploaders/ckeditor_attachment_file_uploader.rb
@@ -34,9 +34,8 @@ class CkeditorAttachmentFileUploader < CarrierWave::Uploader::Base
     Ckeditor.attachment_file_types
   end
 
-  # Override the filename of the uploaded files:
-  # Avoid using model.id or version_name here, see uploader/store.rb for details.
-  # def filename
-  #   "something.jpg" if original_filename
-  # end
+  # Use the model's stored attribute to retrieve the file name
+  def filename
+    model.data_file_name
+  end
 end

--- a/lib/generators/ckeditor/templates/base/carrierwave/uploaders/ckeditor_picture_uploader.rb
+++ b/lib/generators/ckeditor/templates/base/carrierwave/uploaders/ckeditor_picture_uploader.rb
@@ -45,9 +45,8 @@ class CkeditorPictureUploader < CarrierWave::Uploader::Base
     Ckeditor.image_file_types
   end
 
-  # Override the filename of the uploaded files:
-  # Avoid using model.id or version_name here, see uploader/store.rb for details.
-  # def filename
-  #   "something.jpg" if original_filename
-  # end
+  # Use the model's stored attribute to retrieve the file name
+  def filename
+    model.data_file_name
+  end
 end


### PR DESCRIPTION
`Ckeditor::AttachmentFile#filename` returns nil, but 
`Ckeditor::AttachmentFile.first.data_file_name` returns the proper
filename (ie : the filename gets saved). Changing the geneator to this
ensure the name was never nil, both when uploading a new file and when
loading the `index` action.

This may not be the best way to fix the problem, but it worked for me.
Let me know if you can think of a better fix.
