### PR TITLE
Resolves a syntax issue when disabling uploading of an asset

### DIFF
--- a/app/assets/javascripts/ckeditor/config.js
+++ b/app/assets/javascripts/ckeditor/config.js
@@ -83,7 +83,7 @@ CKEDITOR.editorConfig = function( config )
       content = (dialogDefinition.getContents('Upload') || dialogDefinition.getContents('upload'));
       upload = (content == null ? null : content.get('upload'));
       
-      if (upload && upload.filebrowser['params'] == null) {
+      if (upload && upload.filebrowser && upload.filebrowser['params'] === undefined) {
         upload.filebrowser['params'] = config.filebrowserParams();
         upload.action = config.addQueryString(upload.action, upload.filebrowser['params']);
       }


### PR DESCRIPTION
Resolves a syntax issue when disabling uploading of an asset.
When setting the following configuration:

```
config.filebrowserFlashUploadUrl = ''; // Disable Flash Uploading
```
