### PR TITLE
Assets pipeline in ckfinder. Fix for rails 4

### DIFF
--- a/app/views/layouts/ckeditor/application.html.erb
+++ b/app/views/layouts/ckeditor/application.html.erb
@@ -6,8 +6,15 @@
 	<%= csrf_meta_tag %>
 	<%= tag(:meta, :name => "ckeditor-path", :content => Ckeditor.relative_path) %>
   <title><%= I18n.t('page_title', :scope => [:ckeditor]) %></title>
-  
-  <% if Rails.application.config.assets.enabled %>
+
+  <%
+    assets_enabled = if Gem::Version.new(::Rails.version.to_s) >= Gem::Version.new('4.0.0.beta1')
+      defined?(Sprockets::Rails)
+    else
+      Rails.application.config.assets.enabled
+    end
+  %>
+  <% if assets_enabled %>
       <%= stylesheet_link_tag "ckeditor/application" %>
       <%= javascript_include_tag "ckeditor/application" %>
   <% else %>


### PR DESCRIPTION
`config.assets.enabled` was removed from Rails since `Rails 4` and this option returns nil now. 
I added another condition to make ckfinder's assets load properly in `Rails 4`.