### PR TITLE
Fix for 'uninitialized constant Assetable' with mongoid

### DIFF
--- a/lib/ckeditor/helpers/controllers.rb
+++ b/lib/ckeditor/helpers/controllers.rb
@@ -14,7 +14,7 @@ module Ckeditor
         end
         
         def ckeditor_before_create_asset(asset)
-          asset.assetable = ckeditor_current_user
+          asset.assetable = ckeditor_current_user  if respond_to?(:current_user)
           return true
         end
         


### PR DESCRIPTION
This patch is fixing #257. I had the same error, and fix it by this correction
