### PR TITLE
Fixed layout path for Ckeditor::ApplicationController for enabling rails 4 file uploading

### DIFF
--- a/lib/ckeditor/version.rb
+++ b/lib/ckeditor/version.rb
@@ -1,6 +1,6 @@
 module Ckeditor
   module Version
-    GEM = "4.0.5.3".freeze
+    GEM = "4.0.5".freeze
     EDITOR = "4.1.2".freeze
   end
 end


### PR DESCRIPTION
`Ckeditor::ApplicationController` class has no layout path definition,

so in Rails 4, `Ckeditor::PicturesController < Ckeditor::ApplicationController` uses your rails app's `application.html.erb` instead of `ckeditor/application.html.erb` as it's layout so required assets for uploading files are not loaded.

so I added `layout 'ckeditor/application'` in `Ckeditor::ApplicationController`

combined with pull request #276, file uploading in rails 4 will work well.
