### PR TITLE
Force binmode - required for Windows based servers/development

### DIFF
--- a/lib/ckeditor/http.rb
+++ b/lib/ckeditor/http.rb
@@ -46,6 +46,7 @@ module Ckeditor
         @request = request
         
         super Digest::SHA1.hexdigest(filename), tmpdir
+        binmode
         fetch
       end
      


### PR DESCRIPTION
ckeditor uses Tempfile, which, on Windows, is text by default instead of binary. The upshot is that any 0D0A pair of bytes gets corrupted. This change forces binmode, fixing that problem on Windows.
So far this seems to be the only issue I've found on Windows with ckeditor.
