### PR TITLE
Allow configuration of model classes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ckeditor (4.0.5)
+    ckeditor (4.0.6)
       mime-types
       orm_adapter
 

--- a/app/controllers/ckeditor/attachment_files_controller.rb
+++ b/app/controllers/ckeditor/attachment_files_controller.rb
@@ -1,12 +1,12 @@
 class Ckeditor::AttachmentFilesController < Ckeditor::ApplicationController
 
   def index
-    @attachments = Ckeditor.attachment_file_model.find_all(ckeditor_attachment_files_scope)
+    @attachments = Ckeditor.attachment_file_adapter.find_all(ckeditor_attachment_files_scope)
     respond_with(@attachments)
   end
   
   def create
-    @attachment = Ckeditor::AttachmentFile.new
+    @attachment = Ckeditor.attachment_file_model.new
 	  respond_with_asset(@attachment)
   end
   
@@ -18,11 +18,11 @@ class Ckeditor::AttachmentFilesController < Ckeditor::ApplicationController
   protected
   
     def find_asset
-      @attachment = Ckeditor.attachment_file_model.get!(params[:id])
+      @attachment = Ckeditor.attachment_file_adapter.get!(params[:id])
     end
 
     def authorize_resource
-      model = (@attachment || Ckeditor::AttachmentFile)
+      model = (@attachment || Ckeditor.attachment_file_model)
       @authorization_adapter.try(:authorize, params[:action], model)
     end
 end

--- a/app/controllers/ckeditor/pictures_controller.rb
+++ b/app/controllers/ckeditor/pictures_controller.rb
@@ -1,12 +1,12 @@
 class Ckeditor::PicturesController < Ckeditor::ApplicationController
 
   def index
-    @pictures = Ckeditor.picture_model.find_all(ckeditor_pictures_scope)
+    @pictures = Ckeditor.picture_adapter.find_all(ckeditor_pictures_scope)
     respond_with(@pictures) 
   end
   
   def create
-    @picture = Ckeditor::Picture.new
+    @picture = Ckeditor.picture_model.new
 	  respond_with_asset(@picture)
   end
   
@@ -18,11 +18,11 @@ class Ckeditor::PicturesController < Ckeditor::ApplicationController
   protected
   
     def find_asset
-      @picture = Ckeditor.picture_model.get!(params[:id])
+      @picture = Ckeditor.picture_adapter.get!(params[:id])
     end
 
     def authorize_resource
-      model = (@picture || Ckeditor::Picture)
+      model = (@picture || Ckeditor.picture_model)
       @authorization_adapter.try(:authorize, params[:action], model)
     end
 end

--- a/lib/ckeditor.rb
+++ b/lib/ckeditor.rb
@@ -55,7 +55,11 @@ module Ckeditor
   # Turn on/off filename parameterize
   mattr_accessor :parameterize_filenames
   @@parameterize_filenames = true
-  
+
+  # Model classes
+  @@picture_model = nil
+  @@attachment_file_model = nil
+
   # Default way to setup Ckeditor. Run rails generate ckeditor to create
   # a fresh initializer with all configuration values.
   #
@@ -77,13 +81,51 @@ module Ckeditor
   def self.assets
     @@assets ||= Utils.select_assets("ckeditor", "vendor/assets/javascripts") << "ckeditor/init.js"
   end
-  
-  def self.picture_model
-    Ckeditor::Picture.to_adapter
+
+  def self.picture_model(&block)
+    if block_given?
+      self.picture_model = block
+    else
+      @@picture_model_class ||= begin
+        if @@picture_model.respond_to? :call
+          @@picture_model.call
+        else
+          @@picture_model || Ckeditor::Picture
+        end
+      end
+    end
   end
-  
-  def self.attachment_file_model
-    Ckeditor::AttachmentFile.to_adapter
+
+  def self.picture_model=(value)
+    @@picture_model_class = nil
+    @@picture_model = value
+  end
+
+  def self.picture_adapter
+    picture_model.to_adapter
+  end
+
+  def self.attachment_file_model(&block)
+    if block_given?
+      self.attachment_file_model = block
+    else
+      @@attachment_file_model_class ||= begin
+        if @@attachment_file_model.respond_to? :call
+          @@attachment_file_model.call
+        else
+          @@attachment_file_model || Ckeditor::AttachmentFile
+        end
+      end
+    end
+  end
+
+  def self.attachment_file_model=(value)
+    @@attachment_file_model_class = nil
+    @@attachment_file_model = value
+  end
+
+  def self.attachment_file_adapter
+    attachment_file_model.to_adapter
   end
 
   # Setup authorization to be run as a before filter

--- a/lib/generators/ckeditor/templates/ckeditor.rb
+++ b/lib/generators/ckeditor/templates/ckeditor.rb
@@ -16,4 +16,8 @@ Ckeditor.setup do |config|
 
   # Setup authorization to be run as a before filter
   # config.authorize_with :cancan
+
+  # Asset model classes
+  # config.picture_model { Ckeditor::Picture }
+  # config.attachment_file_model { Ckeditor::AttachmentFile }
 end

--- a/test/ckeditor_test.rb
+++ b/test/ckeditor_test.rb
@@ -1,6 +1,11 @@
 require 'test_helper'
 
 class CkeditorTest < ActiveSupport::TestCase
+  def teardown
+    Ckeditor.picture_model = nil
+    Ckeditor.attachment_file_model = nil
+  end
+
   test "truth" do
     assert_kind_of Module, Ckeditor
   end
@@ -10,4 +15,52 @@ class CkeditorTest < ActiveSupport::TestCase
       assert_equal Ckeditor, config
     end
   end
+
+  test 'default picture model' do
+    assert_equal Ckeditor.picture_model, Ckeditor::Picture
+  end
+
+  test 'configuration specifying picture model' do
+    Ckeditor.setup do |config|
+      config.picture_model = CustomPicture
+    end
+    assert_equal Ckeditor.picture_model, CustomPicture
+  end
+
+  test 'configuration specifying picture model using block' do
+    Ckeditor.setup do |config|
+      config.picture_model { CustomPicture }
+    end
+    assert_equal Ckeditor.picture_model, CustomPicture
+  end
+
+  test 'picture model adapter' do
+    assert_equal Ckeditor.picture_adapter, Ckeditor::Picture.to_adapter
+  end
+
+  test 'default attachment file model' do
+    assert_equal Ckeditor.attachment_file_model, Ckeditor::AttachmentFile
+  end
+
+  test 'configuration specifying attachment file model' do
+    Ckeditor.setup do |config|
+      config.attachment_file_model = CustomAttachmentFile
+    end
+    assert_equal Ckeditor.attachment_file_model, CustomAttachmentFile
+  end
+
+  test 'configuration specifying attachment file model using block' do
+    Ckeditor.setup do |config|
+      config.attachment_file_model { CustomAttachmentFile }
+    end
+    assert_equal Ckeditor.attachment_file_model, CustomAttachmentFile
+  end
+
+  test 'attachment file model adapter' do
+    assert_equal Ckeditor.attachment_file_adapter,
+      Ckeditor::AttachmentFile.to_adapter
+  end
+
+  class CustomPicture; end
+  class CustomAttachmentFile; end
 end

--- a/test/support/helpers.rb
+++ b/test/support/helpers.rb
@@ -7,7 +7,7 @@ class ActiveSupport::TestCase
   def new_attachment(data = nil)
     data ||= fixture_file_upload('files/rails.tar.gz', 'application/x-gzip')
     
-    Ckeditor::AttachmentFile.new(:data => data)
+    Ckeditor.attachment_file_model.new(:data => data)
   end
   
   def create_attachment(data = nil)
@@ -19,7 +19,7 @@ class ActiveSupport::TestCase
   def new_picture(data = nil)
     data ||= fixture_file_upload('files/rails.png', 'image/png')
     
-    Ckeditor::Picture.new(:data => data)
+    Ckeditor.picture_model.new(:data => data)
   end
   
   def create_picture(data = nil)


### PR DESCRIPTION
This adds the ability to specify the picture and attachment file model classes in the setup block, instead of having to use `Ckeditor::Picture` and `Ckeditor::AttachmentFile`.

A block is accepted so the class does not need to be loaded at configuration time, which makes life easier when other configuration must be done before the class can be loaded. For example, Dragonfly must be configured before my model classes are loaded so that the Dragonfly accessor can be created, but by default the Dragonfly initialization is done in `config/initializers/ckeditor_dragonfly.rb` _after_ the main `Ckeditor.setup` block in `config/initializers/ckeditor.rb`.
