### PR TITLE
allow to work with Rails 4 production

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ckeditor
 
-CKEditor is a ready-for-use HTML text editor designed to simplify web content creation. It's a WYSIWYG editor that brings common word processor features directly to your web pages. Enhance your website experience with our community maintained editor. 
+CKEditor is a ready-for-use HTML text editor designed to simplify web content creation. It's a WYSIWYG editor that brings common word processor features directly to your web pages. Enhance your website experience with our community maintained editor.
 [ckeditor.com](http://ckeditor.com/)
 
 ## Features
@@ -36,7 +36,7 @@ gem "paperclip"
 
 rails generate ckeditor:install --orm=active_record --backend=paperclip
 ```
-  
+
 #### ActiveRecord + carrierwave
 
 ```
@@ -110,13 +110,60 @@ app/assets/javascripts/ckeditor/config.js
 app/assets/javascripts/ckeditor/contents.css
 ```
 
+### Usage with Rails 4 assets
+
+In order to use rails 4 assets with digest in production environment you need some preparing.
+
+First, you need to include in `application.js` **before** `ckeditor/init`
+
+```
+//= require ckeditor/override
+```
+
+It forces ckeditor core to respect digested assets.
+
+Next you need to check, that some non-core plugins and skins don't use core ckeditor functions
+to determine path to assets. For the latter we must determine task to copy non-digest assets in
+assets folder. Some example of such rake task is:
+
+```ruby
+namespace :ckeditor do
+  def copy_assets(regexp)
+    Rails.application.assets.each_logical_path(regexp) do |name, path|
+      asset = Rails.root.join('public', 'assets', name)
+      p "Copy #{path} to #{asset}"
+      FileUtils.cp path, asset
+    end
+  end
+
+  desc 'Copy ckeditor assets, that cant be used with digest'
+  task copy_nondigest_assets: :environment do
+    copy_assets /ckeditor\/contents.css/
+    copy_assets /ckeditor\/skins\/moono\/.+png/
+  end
+end
+```
+
+You can include this rake task in capistrano task (if you are deploying via capistrano):
+
+```ruby
+desc 'copy ckeditor nondigest assets'
+task :copy_nondigest_assets, roles: :app do
+  run "cd #{latest_release} && #{rake} RAILS_ENV=#{rails_env} ckeditor:copy_nondigest_assets"
+end
+after 'deploy:assets:precompile', 'copy_nondigest_assets'
+```
+
+Periodically check your error monitoring tool, if you see some part of ckeditor try to load
+unexisted non-digest asset - just add it in ckeditor rake task.
+
 ### AJAX
 
 jQuery sample:
 
 ```html
 <script type='text/javascript' charset='UTF-8'>
-  $(document).ready(function(){  
+  $(document).ready(function(){
     $('form[data-remote]').bind("ajax:before", function(){
       for (instance in CKEDITOR.instances){
         CKEDITOR.instances[instance].updateElement();
@@ -182,7 +229,7 @@ en:
 $> rake test
 $> rake test CKEDITOR_ORM=mongoid
 $> rake test CKEDITOR_BACKEND=carrierwave
-  
+
 $> rake test:controllers
 $> rake test:generators
 $> rake test:integration

--- a/app/assets/javascripts/ckeditor/override.js.erb
+++ b/app/assets/javascripts/ckeditor/override.js.erb
@@ -1,0 +1,21 @@
+window['CKEDITOR_BASEPATH'] = "/assets/ckeditor/";
+
+window.CKEDITOR_ASSETS_MAPPING = {
+<% Rails.application.assets.each_logical_path(->(path){ path =~ /ckeditor/ && path != 'ckeditor/override.js' }) do |asset| %>
+  "<%= asset %>": "<%= asset_path(asset) %>",
+<% end %>
+}
+
+window.CKEDITOR_GETURL = function( resource ) {
+  // If this is not a full or absolute path.
+  if ( resource.indexOf( ':/' ) == -1 && resource.indexOf( '/' ) !== 0 )
+    resource = this.basePath + resource;
+
+  // Add the timestamp, except for directories.
+  if ( resource.charAt( resource.length - 1 ) != '/'  ){
+    var url = resource.match( /^(.*?:\/\/[^\/]*)\/assets\/(.+)/ );
+    if(url) resource = url[1] + (CKEDITOR_ASSETS_MAPPING[url[2]] || '/assets/' + url[2]);
+  }
+
+  return resource;
+}


### PR DESCRIPTION
This patch adds additional javascript and doesn't change functionality of existing gem.

If some user want to use ckeditor in rails 4 production, all he needs is to require this javascript and add tiny rake task in own rails application code, as described in `readme`.

I already use this patch in my production, if I detect any errors in future, I'll fix these.
