### PR TITLE
Create directories which may not exist before copying files

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ namespace :ckeditor do
     Rails.application.assets.each_logical_path(regexp) do |name, path|
       asset = Rails.root.join('public', 'assets', name)
       p "Copy #{path} to #{asset}"
+      FileUtils.mkdir_p(File.dirname(asset))
       FileUtils.cp path, asset
     end
   end


### PR DESCRIPTION
If we have custom plugins or skins under /assets/javascripts/ckeditor we
need to make sure we're creating those folders before assets can be 
copied to them.
