### PR TITLE
Remove "respond_to?(:current_user)" again...

### DIFF
--- a/lib/ckeditor/helpers/controllers.rb
+++ b/lib/ckeditor/helpers/controllers.rb
@@ -14,7 +14,7 @@ module Ckeditor
         end
         
         def ckeditor_before_create_asset(asset)
-          asset.assetable = ckeditor_current_user  if respond_to?(:current_user)
+          asset.assetable = ckeditor_current_user
           return true
         end
         


### PR DESCRIPTION
This reverts commit 1cc9474765678fc52911949c8e0a95ef3e59c53c.

If we encapsulate identification with ckeditor_current_user, why use again current_user?

Also, this usually does not work, sin `current_user` usually is a private/protected method...
