### PR TITLE
remove host from resource url

### DIFF
--- a/app/assets/javascripts/ckeditor/override.js.erb
+++ b/app/assets/javascripts/ckeditor/override.js.erb
@@ -14,7 +14,7 @@ window.CKEDITOR_GETURL = function( resource ) {
   // Add the timestamp, except for directories.
   if ( resource.charAt( resource.length - 1 ) != '/'  ){
     var url = resource.match( /^(.*?:\/\/[^\/]*)\/assets\/(.+)/ );
-    if(url) resource = url[1] + (CKEDITOR_ASSETS_MAPPING[url[2]] || '/assets/' + url[2]);
+    if(url) resource = (CKEDITOR_ASSETS_MAPPING[url[2]] || '/assets/' + url[2]);
   }
 
   return resource;


### PR DESCRIPTION
this allows the use of asset_host and ckeditor and still works without asset_host set as the /assets is a valid relative path
