### PR TITLE
Fixes issue with ckeditor BASEPATH in subdir (passenger) enviroment

### DIFF
--- a/app/assets/javascripts/ckeditor/override.js.erb
+++ b/app/assets/javascripts/ckeditor/override.js.erb
@@ -1,4 +1,4 @@
-window['CKEDITOR_BASEPATH'] = "/assets/ckeditor/";
+window['CKEDITOR_BASEPATH'] = <%= ENV["RAILS_RELATIVE_URL_ROOT"] ? "#{ENV["RAILS_RELATIVE_URL_ROOT"]}/assets/ckeditor" : "/assets/ckeditor/" %> ;
 
 window.CKEDITOR_ASSETS_MAPPING = {
 <% Rails.application.assets.each_logical_path(->(path){ path =~ /ckeditor/ && path != 'ckeditor/override.js' }) do |asset| %>


### PR DESCRIPTION
Hi. After all this time using github it is my first try of contribution so feel free to criticize ;)

This little fix add an `ENV["RAILS_RELATIVE_URL_ROOT"]` if exist to `window['CKEDITOR_BASEPATH']` in an override.js file (for rails 4). 

Hardcoded path to `/assets/ckeditor/` unabled to found assets of ckeditor if app is runing in a subdir.   Now it gather an rails ENV variable (delivered by passenger in `PassengerBaseURI` option)
