### PR TITLE
fix(override.js.erb): map assets from ckeditor path scope

### DIFF
--- a/app/assets/javascripts/ckeditor/override.js.erb
+++ b/app/assets/javascripts/ckeditor/override.js.erb
@@ -1,7 +1,7 @@
 window['CKEDITOR_BASEPATH'] = "/assets/ckeditor/";
 
 window.CKEDITOR_ASSETS_MAPPING = {
-<% Rails.application.assets.each_logical_path(->(path){ path =~ /ckeditor/ && path != 'ckeditor/override.js' }) do |asset| %>
+<% Rails.application.assets.each_logical_path(->(path){ path =~ /ckeditor\// && path != 'ckeditor/override.js' }) do |asset| %>
   "<%= asset %>": "<%= asset_path(asset) %>",
 <% end %>
 }


### PR DESCRIPTION
fix for assets mapping regexp

I have `assets/stylesheets/_ckeditor_overrides.sass` and assets mappings take it, but shouldn't.
So I have `assets:precompile` failure on it.