### PR TITLE
Fix override.js CKEDITOR_BASEPATH, and respect user setting, and recompile override.js when related assets are modified.

### DIFF
--- a/app/assets/javascripts/ckeditor/depends.js
+++ b/app/assets/javascripts/ckeditor/depends.js
@@ -1,0 +1,5 @@
+/*
+    Include any additional depends_on_asset or depends_on directives here.
+    Include all files for any additional plugins you may have installed.
+    If any of these are changed, then ckeditor/override.js will be recompiled to get the proper compiled asset path.
+*/

--- a/app/assets/javascripts/ckeditor/override.js.erb
+++ b/app/assets/javascripts/ckeditor/override.js.erb
@@ -1,3 +1,10 @@
+/*
+ If any of the assets below are changed, this file will be re-compiled as well.
+ */
+//= depend_on_asset ckeditor/config.js
+//= depend_on_asset ckeditor/ckeditor.js
+//= depend_on_asset ckeditor/depends.js
+//= depend_on ckeditor/CHANGES.md
 
 if (typeof window['CKEDITOR_BASEPATH'] === "undefined" || window['CKEDITOR_BASEPATH'] === null) {
     window['CKEDITOR_BASEPATH'] = "<%= asset_path(Ckeditor.asset_path) %>/";

--- a/app/assets/javascripts/ckeditor/override.js.erb
+++ b/app/assets/javascripts/ckeditor/override.js.erb
@@ -1,4 +1,7 @@
-window['CKEDITOR_BASEPATH'] = "/assets/ckeditor/";
+
+if (typeof window['CKEDITOR_BASEPATH'] === "undefined" || window['CKEDITOR_BASEPATH'] === null) {
+    window['CKEDITOR_BASEPATH'] = "<%= asset_path(Ckeditor.asset_path) %>/";
+}
 
 window.CKEDITOR_ASSETS_MAPPING = {
 <% Rails.application.assets.each_logical_path(->(path){ path =~ /ckeditor/ && path != 'ckeditor/override.js' }) do |asset| %>


### PR DESCRIPTION
The value for CKEDITOR_BASEPATH is not being set correctly in override.js.erb, and it is also overriding any user supplied values for this setting that may come before this.  This pull request changes the behavior to match that of init.js.erb