### PR TITLE
renamed create_migration method to avoid name collision with rails

### DIFF
--- a/lib/generators/ckeditor/install_generator.rb
+++ b/lib/generators/ckeditor/install_generator.rb
@@ -51,7 +51,7 @@ module Ckeditor
         end
       end
 
-      def create_migration
+      def create_ckeditor_migration
         if ["active_record"].include?(orm)
           migration_template "#{generator_dir}/migration.rb", File.join('db/migrate', "create_ckeditor_assets.rb")
         end


### PR DESCRIPTION
fixes #424
