### PR TITLE
fix for 'CKEDITOR undefined' problem

### DIFF
--- a/lib/ckeditor/utils.rb
+++ b/lib/ckeditor/utils.rb
@@ -23,7 +23,7 @@ module Ckeditor
       end
 
       def js_replace(dom_id, options = nil)
-        js = ["if (typeof CKEDITOR != 'undefined') {"]
+        js = ["(function() { if (typeof CKEDITOR != 'undefined') {"]
 
         if options && !options.keys.empty?
           js_options = ActiveSupport::JSON.encode(options)
@@ -32,7 +32,7 @@ module Ckeditor
           js << "CKEDITOR.replace('#{dom_id}');"
         end
 
-        js << "}"
+        js << "} else { setTimeout(arguments.callee, 50); } })();"
         js.join(" ").html_safe
       end
 

--- a/test/dummy/app/views/layouts/application.html.erb
+++ b/test/dummy/app/views/layouts/application.html.erb
@@ -2,13 +2,13 @@
 <html>
 <head>
   <title>Dummy</title>
-  <%= stylesheet_link_tag    "application" %>
-  <%= javascript_include_tag "application" %>
+  <%= stylesheet_link_tag "application" %>
   <%= csrf_meta_tags %>
 </head>
 <body>
 
 <%= yield %>
 
+  <%= javascript_include_tag "application" %>
 </body>
 </html>


### PR DESCRIPTION
Fixes #17 #105 #200 #214 #228 #230 #239 #368 #415.

Many users include javascript files at the bottom of the application layout as advised by many Javascript Gurus. So in the script file generated by cktext_area:

``` html
<script type="text/javascript">
//<![CDATA[
if (typeof CKEDITOR != 'undefined') { CKEDITOR.replace(...) }
//]]>
</script>
```

`CKEDITOR` remains undefined thus replace function is never called. It works only when javascript include tag is added before the cktext_area form field.

This fix generates the script file like this:

``` html
</textarea><script type="text/javascript">
//<![CDATA[
(function() { 
  if (typeof CKEDITOR != 'undefined') { 
    CKEDITOR.replace(.....) ;
  } else { 
    setTimeout(arguments.callee, 50); 
  } 
})();
//]]>
</script>
```

Now, so long as `CKEDITOR` is undefined, the self invoking function keeps calling itself at a fixed time interval. Once the ckeditor's javascript file gets loaded and `CKEDITOR` gets defined, the function calls the replace function and exits the cycle. Now the config options set in the form field work.
