### PR TITLE
Add config option to specify path for assets:precompile

### DIFF
--- a/lib/ckeditor.rb
+++ b/lib/ckeditor.rb
@@ -54,6 +54,10 @@ module Ckeditor
   mattr_accessor :asset_path
   @@asset_path = nil
 
+  # Ckeditor assets path for precompile list in production
+  mattr_accessor :asset_precompile_path
+  @@asset_precompile_path = nil
+
   # Ckeditor assets for precompilation
   mattr_accessor :assets
   @@assets = nil
@@ -95,6 +99,10 @@ module Ckeditor
 
   def self.base_path
     @base_path ||= (asset_path || File.join([Rails.application.config.assets.prefix, '/ckeditor/']))
+  end
+
+  def self.asset_precompile_path
+    @@asset_precompile_path ||= root_path
   end
 
   # All css and js files from ckeditor folder

--- a/lib/ckeditor/utils.rb
+++ b/lib/ckeditor/utils.rb
@@ -69,7 +69,7 @@ module Ckeditor
       end
 
       def select_assets(path, relative_path)
-        relative_folder = Ckeditor.root_path.join relative_path
+        relative_folder = Ckeditor.asset_precompile_path.join relative_path
         folder = relative_folder.join path
         extensions = '*.{js,css,png,gif,jpg}'
 


### PR DESCRIPTION
Sometimes I want to override ckeditor from the gem with the custom built version from ckeditor.com.
It works fine in the development, but I'm having issues in production, because `Ckeditor::Utils.select_assets` uses `Ckeditor.root_path` as a root folder when it collects the assets for precompile list.

I suggest to add a new option: `asset_precompile_path` which would allow to use `vendor/assets/ckeditor` folder from my app instead. 


Usage:
``` ruby
# Use this hook to configure ckeditor
Ckeditor.setup do |config|
 # Use app folder as a root folder for precompile list in production
  config.asset_precompile_path = Rails.root
end