### PR TITLE
added wrapper_options argument to def input

### DIFF
--- a/lib/ckeditor/hooks/simple_form.rb
+++ b/lib/ckeditor/hooks/simple_form.rb
@@ -2,7 +2,7 @@ require 'simple_form'
 
 module Ckeditor::Hooks::SimpleForm
   class CkeditorInput < ::SimpleForm::Inputs::Base
-    def input
+    def input(wrapper_options = nil)
       @builder.cktext_area(attribute_name, input_html_options)
     end
   end


### PR DESCRIPTION
Removed this deprecation warning:

```
DEPRECATION WARNING: input method now accepts a `wrapper_options` argument. The method definition without the argument is deprecated and will be removed in the next Simple Form version. Change your code from:

def input

to

def input(wrapper_options)

See https://github.com/plataformatec/simple_form/pull/997 for more information.
(called from render at /home/vagrant/.rvm/gems/ruby-2.0.0-p353@global/bundler/gems/simple_form-d7306558665d/lib/simple_form/wrappers/leaf.rb:15)
```
