### PR TITLE
Allow for aboslute paths without full URL.

### DIFF
--- a/app/assets/javascripts/ckeditor/override.js.erb
+++ b/app/assets/javascripts/ckeditor/override.js.erb
@@ -14,7 +14,7 @@ window.CKEDITOR_GETURL = function( resource ) {
   // Add the timestamp, except for directories.
   if ( resource.charAt( resource.length - 1 ) != '/'  ){
     var url = resource.match( /^(.*?:\/\/[^\/]*)?<%= Rails.configuration.relative_url_root.to_s.gsub('/', '\/') %>\/assets\/(.+)/ );
-    if(url) resource = (CKEDITOR_ASSETS_MAPPING[url[2]] || '/assets/' + url[2]);
+    if(url) resource = (CKEDITOR_ASSETS_MAPPING[url[2]] || '<%= Rails.configuration.relative_url_root %>/assets/' + url[2]);
   }
 
   return resource;

--- a/app/assets/javascripts/ckeditor/override.js.erb
+++ b/app/assets/javascripts/ckeditor/override.js.erb
@@ -13,7 +13,7 @@ window.CKEDITOR_GETURL = function( resource ) {
 
   // Add the timestamp, except for directories.
   if ( resource.charAt( resource.length - 1 ) != '/'  ){
-    var url = resource.match( /^(.*?:\/\/[^\/]*)\/assets\/(.+)/ );
+    var url = resource.match( /^(.*?:\/\/[^\/]*)?<%= Rails.configuration.relative_url_root %>\/assets\/(.+)/ );
     if(url) resource = (CKEDITOR_ASSETS_MAPPING[url[2]] || '/assets/' + url[2]);
   }
 

--- a/app/assets/javascripts/ckeditor/override.js.erb
+++ b/app/assets/javascripts/ckeditor/override.js.erb
@@ -13,7 +13,7 @@ window.CKEDITOR_GETURL = function( resource ) {
 
   // Add the timestamp, except for directories.
   if ( resource.charAt( resource.length - 1 ) != '/'  ){
-    var url = resource.match( /^(.*?:\/\/[^\/]*)?<%= Rails.configuration.relative_url_root %>\/assets\/(.+)/ );
+    var url = resource.match( /^(.*?:\/\/[^\/]*)?<%= Rails.configuration.relative_url_root.to_s.gsub('/', '\/') %>\/assets\/(.+)/ );
     if(url) resource = (CKEDITOR_ASSETS_MAPPING[url[2]] || '/assets/' + url[2]);
   }
 


### PR DESCRIPTION
It's possible I don't 100% understand what you're trying to do here, but in order to get the URL mapping to work properly, I had to add the relative_url_root into the regex (I forgot that with the first pull request).  I also had to make the regex match whether or not the full URL was included.  This is because often paths come in like /assets/custom_ckeditor_config.js.  The first if doesn't prepend the basepath because it's absolute, but the regex doesn't catch it because it doesn't have http://hostname/ in front of it.  The reason for this is that when doing sub-URI deployments, you have to use the helpers to move seamlessly between dev and prod where  the /sub-uri isn't always present.  The rails/sass helpers usually generate an absolute path.