### PR TITLE
Preserve modified time when creating non-digest

### DIFF
--- a/lib/tasks/ckeditor.rake
+++ b/lib/tasks/ckeditor.rake
@@ -7,7 +7,7 @@ task "assets:precompile" do
     next unless file =~ fingerprint
     nondigest = file.sub fingerprint, '.'
     if !File.exist?(nondigest) or File.mtime(file) > File.mtime(nondigest)
-      FileUtils.cp file, nondigest, verbose: true
+      FileUtils.cp file, nondigest, verbose: true, preserve: true
     end
   end
 end


### PR DESCRIPTION
If, for whatever reason, there are two versions of a digest tagged asset which are newer than the current version, the old of the two could be incorrectly selected. This should fix that.
