### PR TITLE
Fix rescue problem on ApplicationController

### DIFF
--- a/app/controllers/ckeditor/application_controller.rb
+++ b/app/controllers/ckeditor/application_controller.rb
@@ -1,4 +1,4 @@
-class Ckeditor::ApplicationController < ActionController::Base
+class Ckeditor::ApplicationController < ApplicationController
   respond_to :html, :json
   layout 'ckeditor/application'
 


### PR DESCRIPTION
Ckeditor::ApplicationController need to extend from ApplicationController otherwise it can't catch the rescue in the ApplicationController of App
