### PR TITLE
Clarify rails 4 asset pipeline inclusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,12 @@ app/assets/javascripts/ckeditor/contents.css
 
 ### Deployment
 
+For rails 4, add the following to `config/initializers/assets.rb`:
+
+```ruby
+Rails.application.config.assets.precompile += %w( ckeditor/* )
+```
+
 Since version 4.1.0, non-digested assets of ckeditor will simply be copied after digested assets were compiled.
 For older versions, use gem [non-stupid-digest-assets](https://rubygems.org/gems/non-stupid-digest-assets), to copy non digest assets.
 


### PR DESCRIPTION
Rails 4 requires specifically marking the assets for ckeditor for precompilation or assets:precompile won't work correctly and ckeditor won't run on production environments.

I got this approach from https://github.com/galetahub/ckeditor/issues/468 and it'd certainly have saved me some time :)
