### PR TITLE
remove display none from pagination css

### DIFF
--- a/app/assets/javascripts/ckeditor/filebrowser/stylesheets/uploader.css.erb
+++ b/app/assets/javascripts/ckeditor/filebrowser/stylesheets/uploader.css.erb
@@ -118,5 +118,5 @@ img {
 }
 
 .pagination, .pagination a {
-	display: none;
+    text-decoration: none;
 }


### PR DESCRIPTION
In the file browser the next link of pagination doesn't show up with `display: none`.
`text-decoration: none` is added to remove underline from the link.
