### PR TITLE
Change ckeditor path to relative

### DIFF
--- a/lib/ckeditor.rb
+++ b/lib/ckeditor.rb
@@ -48,7 +48,7 @@ module Ckeditor
 
   # Ckeditor files destination path
   mattr_accessor :relative_path
-  @@relative_path = '/ckeditor'
+  @@relative_path = 'ckeditor'
 
   # Ckeditor assets path
   mattr_accessor :asset_path

--- a/test/models/attachment_file_test.rb
+++ b/test/models/attachment_file_test.rb
@@ -17,6 +17,6 @@ class AttachmentFileTest < ActiveSupport::TestCase
 
     assert_equal "application/x-gzip", @attachment.data_content_type
     assert_equal 6823, @attachment.data_file_size
-    assert_equal "/ckeditor/filebrowser/images/thumbs/gz.gif", @attachment.url_thumb
+    assert_equal "ckeditor/filebrowser/images/thumbs/gz.gif", @attachment.url_thumb
   end
 end

--- a/test/models/utils_test.rb
+++ b/test/models/utils_test.rb
@@ -3,16 +3,16 @@ require 'test_helper'
 class UtilsTest < ActiveSupport::TestCase
   test 'exists filethumb' do
     %w(avi doc docx exe gz htm jpg mp3 mpg pdf psd rar swf tar txt wmv xlsx zip).each do |ext|
-      assert_equal "/ckeditor/filebrowser/images/thumbs/#{ext}.gif", Ckeditor::Utils.filethumb("somefile.#{ext}")
+      assert_equal "ckeditor/filebrowser/images/thumbs/#{ext}.gif", Ckeditor::Utils.filethumb("somefile.#{ext}")
     end
 
-    assert_equal "/ckeditor/filebrowser/images/thumbs/unknown.gif", Ckeditor::Utils.filethumb("somefile.ddd")
+    assert_equal "ckeditor/filebrowser/images/thumbs/unknown.gif", Ckeditor::Utils.filethumb("somefile.ddd")
   end
 
   test 'wrong filethumb' do
-    assert_equal "/ckeditor/filebrowser/images/thumbs/unknown.gif", Ckeditor::Utils.filethumb("somefile.ddd")
-    assert_equal "/ckeditor/filebrowser/images/thumbs/unknown.gif", Ckeditor::Utils.filethumb("somefile")
-    assert_equal "/ckeditor/filebrowser/images/thumbs/unknown.gif", Ckeditor::Utils.filethumb("")
-    assert_equal "/ckeditor/filebrowser/images/thumbs/unknown.gif", Ckeditor::Utils.filethumb(nil)
+    assert_equal "ckeditor/filebrowser/images/thumbs/unknown.gif", Ckeditor::Utils.filethumb("somefile.ddd")
+    assert_equal "ckeditor/filebrowser/images/thumbs/unknown.gif", Ckeditor::Utils.filethumb("somefile")
+    assert_equal "ckeditor/filebrowser/images/thumbs/unknown.gif", Ckeditor::Utils.filethumb("")
+    assert_equal "ckeditor/filebrowser/images/thumbs/unknown.gif", Ckeditor::Utils.filethumb(nil)
   end
 end


### PR DESCRIPTION
Ckeditor path needs to be relative to allow image_tag helper generate the right path

`<%= image_tag '/ckeditor/filebrowser/images/thumbs/pdf.gif’>`
generates
`<img src="/ckeditor/filebrowser/images/thumbs/pdf.gif">`

`<%= image_tag 'ckeditor/filebrowser/images/thumbs/pdf.gif’>`
generates
`<img src="/assets/ckeditor/filebrowser/images/thumbs/pdf.gif">`
