### PR TITLE
Fixes error when uploading not allowed files

### DIFF
--- a/app/controllers/ckeditor/application_controller.rb
+++ b/app/controllers/ckeditor/application_controller.rb
@@ -23,7 +23,7 @@ class Ckeditor::ApplicationController < ApplicationController
       else
         if params[:CKEditor]
           render :text => %Q"<script type='text/javascript'>
-              window.parent.CKEDITOR.tools.callFunction(#{params[:CKEditorFuncNum]}, null, '#{asset.errors.full_messages.first}');
+              window.parent.CKEDITOR.tools.callFunction(#{params[:CKEditorFuncNum]}, null, '#{Ckeditor::Utils.escape_single_quotes(asset.errors.full_messages.first)}');
             </script>"
         else
           render :nothing => true


### PR DESCRIPTION
To reproduce:

(we are using it on rails admin but I think it is the same on a standard instance of ck editor)
1. Click on "Link"
2. Switch to "Upload" tab
3. Add a `.txt` file
4. Click on "Send it to the server"
5. Click "OK"

You will get an error in the console:
![screen shot 2014-12-01 at 17 30 32](https://cloud.githubusercontent.com/assets/556268/5249030/3cf94f04-7980-11e4-8b28-daad8132d370.png)

The reason is the unescaped quote here:
![screen shot 2014-12-01 at 17 31 06](https://cloud.githubusercontent.com/assets/556268/5249039/4a75f97a-7980-11e4-9d00-7baf38760dbe.png)

This PR solves this issue.

I wanted to add a failing test but it would require too much time on my side, sorry
