### PR TITLE
Set @_authorized instance variable in controller on cancan authorization

### DIFF
--- a/lib/ckeditor/hooks/cancan.rb
+++ b/lib/ckeditor/hooks/cancan.rb
@@ -19,7 +19,10 @@ module Ckeditor
       # action as a symbol (:create, :destroy, etc.). The second argument is the actual model
       # instance if it is available.
       def authorize(action, model_object = nil)
-        @controller.current_ability.authorize!(action.to_sym, model_object) if action
+        if action
+          @controller.instance_variable_set(:@_authorized, true)
+          @controller.current_ability.authorize!(action.to_sym, model_object)
+        end
       end
 
       # This method is called primarily from the view to determine whether the given user


### PR DESCRIPTION
Cancan raises AuthorizationNotPerformed error unless controller has
@_authorized instance variable set. Normally authorize! helper method
sets this, but as ckeditor's cancan integration reimplements this it needs
to be set manually.

Related previous pull requests:

https://github.com/galetahub/ckeditor/pull/460
https://github.com/galetahub/ckeditor/pull/308