### PR TITLE
Refactor attachment and picture controllers to work without responders

### DIFF
--- a/app/controllers/ckeditor/application_controller.rb
+++ b/app/controllers/ckeditor/application_controller.rb
@@ -1,5 +1,4 @@
 class Ckeditor::ApplicationController < ApplicationController
-  respond_to :html, :json
   layout 'ckeditor/application'
 
   before_filter :find_asset, :only => [:destroy]
@@ -15,18 +14,20 @@ class Ckeditor::ApplicationController < ApplicationController
       callback = ckeditor_before_create_asset(asset)
 
       if callback && asset.save
-        body = params[:CKEditor].blank? ? asset.to_json(:only=>[:id, :type]) : %Q"<script type='text/javascript'>
-          window.parent.CKEDITOR.tools.callFunction(#{params[:CKEditorFuncNum]}, '#{config.relative_url_root}#{Ckeditor::Utils.escape_single_quotes(asset.url_content)}');
-        </script>"
-
-        render :text => body
+        if params[:CKEditor].blank?
+          render :json => asset.to_json(:only=>[:id, :type])
+        else
+          render :text => %Q"<script type='text/javascript'>
+              window.parent.CKEDITOR.tools.callFunction(#{params[:CKEditorFuncNum]}, '#{config.relative_url_root}#{Ckeditor::Utils.escape_single_quotes(asset.url_content)}');
+            </script>"
+        end
       else
-        if params[:CKEditor]
+        if params[:CKEditor].blank?
+          render :nothing => true, :format => :json
+        else
           render :text => %Q"<script type='text/javascript'>
               window.parent.CKEDITOR.tools.callFunction(#{params[:CKEditorFuncNum]}, null, '#{Ckeditor::Utils.escape_single_quotes(asset.errors.full_messages.first)}');
             </script>"
-        else
-          render :nothing => true
         end
       end
     end

--- a/app/controllers/ckeditor/attachment_files_controller.rb
+++ b/app/controllers/ckeditor/attachment_files_controller.rb
@@ -4,7 +4,9 @@ class Ckeditor::AttachmentFilesController < Ckeditor::ApplicationController
     @attachments = Ckeditor.attachment_file_adapter.find_all(ckeditor_attachment_files_scope)
     @attachments = Ckeditor::Paginatable.new(@attachments).page(params[:page])
 
-    respond_with(@attachments, :layout => @attachments.first_page?)
+    respond_to do |format|
+      format.html { render :layout => @attachments.first_page? }
+    end
   end
 
   def create
@@ -14,7 +16,11 @@ class Ckeditor::AttachmentFilesController < Ckeditor::ApplicationController
 
   def destroy
     @attachment.destroy
-    respond_with(@attachment, :location => attachment_files_path)
+
+    respond_to do |format|
+      format.html { redirect_to attachment_files_path }
+      format.json { render :nothing => true, :status => 204 }
+    end
   end
 
   protected

--- a/app/controllers/ckeditor/pictures_controller.rb
+++ b/app/controllers/ckeditor/pictures_controller.rb
@@ -4,7 +4,9 @@ class Ckeditor::PicturesController < Ckeditor::ApplicationController
     @pictures = Ckeditor.picture_adapter.find_all(ckeditor_pictures_scope)
     @pictures = Ckeditor::Paginatable.new(@pictures).page(params[:page])
 
-    respond_with(@pictures, :layout => @pictures.first_page?)
+    respond_to do |format|
+      format.html { render :layout => @pictures.first_page? }
+    end
   end
 
   def create
@@ -14,7 +16,11 @@ class Ckeditor::PicturesController < Ckeditor::ApplicationController
 
   def destroy
     @picture.destroy
-    respond_with(@picture, :location => pictures_path)
+
+    respond_to do |format|
+      format.html { redirect_to pictures_path }
+      format.json { render :nothing => true, :status => 204 }
+    end
   end
 
   protected


### PR DESCRIPTION
The responders gem was deprecated as of Rails 4.2, so I refactored the code to avoid another dependency. Users of Rails 4.2 will see an unpleasant error saying to include the responders gem, whenever they try to view uploaded files, which this PR avoids. The changes should be backwards compatible with older Rails versions.

The tests are green, and I did some manual testing just to be sure everything is OK.