### PR TITLE
Update Dragonfly backend and generators to work with Dragonfly 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,16 @@ gem 'mini_magick'
 rails generate ckeditor:install --orm=active_record --backend=carrierwave
 ```
 
+#### ActiveRecord + dragonfly
+
+Requires Dragonfly 1.0 or greater.
+
+```
+gem 'dragonfly'
+
+rails generate ckeditor:install --orm=active_record --backend=dragonfly
+```
+
 #### Mongoid + paperclip
 
 ```

--- a/lib/ckeditor/backend/dragonfly.rb
+++ b/lib/ckeditor/backend/dragonfly.rb
@@ -2,24 +2,26 @@ module Ckeditor
   module Backend
     module Dragonfly
       def self.included(base)
-        base.send(:include, InstanceMethods)
+        base.send(:extend, ::Dragonfly::Model)
+        base.send(:extend, ::Dragonfly::Model::Validations)
         base.send(:extend, ClassMethods)
+        base.send(:include, InstanceMethods)
       end
 
       module ClassMethods
         def attachment_file_types
-          @attachment_file_types ||= Ckeditor.attachment_file_types.map(&:to_sym).tap do |formats|
+          @attachment_file_types ||= Ckeditor.attachment_file_types.map(&:to_s).tap do |formats|
             # This is not ideal but Dragonfly doesn't return double
             # extensions. Having said that, the other backends
             # currently don't use attachment_file_types at all.
-            [ :bz2, :gz, :lzma, :xz ].each do |f|
-              formats << f if formats.include?("tar.#{f}".to_sym)
+            [ 'bz2', 'gz', 'lzma', 'xz' ].each do |f|
+              formats << f if formats.include?("tar.#{f}")
             end
           end
         end
 
         def image_file_types
-          @image_file_types ||= Ckeditor.image_file_types.map(&:to_sym)
+          @image_file_types ||= Ckeditor.image_file_types.map(&:to_s)
         end
       end
 
@@ -27,7 +29,7 @@ module Ckeditor
         delegate :url, :path, :size, :image?, :width, :height, :to => :data
 
         alias_attribute :data_file_name, :data_name
-        alias_attribute :data_content_type, :data_mime_type
+        alias_attribute :data_content_type, :"data.mime_type"
         alias_attribute :data_file_size, :data_size
 
         private

--- a/lib/generators/ckeditor/templates/active_record/dragonfly/ckeditor/asset.rb
+++ b/lib/generators/ckeditor/templates/active_record/dragonfly/ckeditor/asset.rb
@@ -2,6 +2,6 @@ class Ckeditor::Asset < ActiveRecord::Base
   include Ckeditor::Orm::ActiveRecord::AssetBase
   include Ckeditor::Backend::Dragonfly
 
-  ckeditor_file_accessor :data
+  dragonfly_accessor :data, app: :ckeditor
   validates_presence_of :data
 end

--- a/lib/generators/ckeditor/templates/active_record/dragonfly/ckeditor/attachment_file.rb
+++ b/lib/generators/ckeditor/templates/active_record/dragonfly/ckeditor/attachment_file.rb
@@ -1,5 +1,5 @@
 class Ckeditor::AttachmentFile < Ckeditor::Asset
-  validates_property :format, :of => :data, :in => attachment_file_types unless attachment_file_types.empty?
+  validates_property :ext, :of => :data, :in => attachment_file_types unless attachment_file_types.empty?
 
   def url_thumb
     Ckeditor::Utils.filethumb(filename)

--- a/lib/generators/ckeditor/templates/base/dragonfly/initializer.rb
+++ b/lib/generators/ckeditor/templates/base/dragonfly/initializer.rb
@@ -1,26 +1,20 @@
-# Load Dragonfly for Rails if it isn't loaded already.
-require "dragonfly/rails/images"
+# Load Dragonfly if it isn't loaded already.
+require "dragonfly"
 
-# Use a separate Dragonfly "app" for CKEditor.
-app = Dragonfly[:ckeditor]
-app.configure_with(:rails)
-app.configure_with(:imagemagick)
+Dragonfly.app(:ckeditor).configure do
+  plugin :imagemagick
+  secret "<%= SecureRandom.hex(32) %>"
 
-# Define the ckeditor_file_accessor macro.
-app.define_macro(ActiveRecord::Base, :ckeditor_file_accessor) if defined?(ActiveRecord::Base)
-app.define_macro_on_include(Mongoid::Document, :ckeditor_file_accessor) if defined?(Mongoid::Document)
-
-app.configure do |c|
   # Store files in public/uploads/ckeditor. This is not
   # mandatory and the files don't even have to be stored under
-  # public. If not storing under public then set server_root to nil.
-  c.datastore.root_path = Rails.root.join("public", "uploads", "ckeditor", Rails.env).to_s
-  c.datastore.server_root = Rails.root.join("public").to_s
+  # public. See http://markevans.github.io/dragonfly/data-stores
+  datastore :file,
+    root_path: Rails.root.join("public", "uploads", "ckeditor", Rails.env).to_s,
+    server_root: 'public'
 
-  # Accept asset requests on /ckeditor_assets. Again, this is not
-  # mandatory. Just be sure to include :job somewhere.
-  c.url_format = "/uploads/ckeditor/:job/:basename.:format"
+  # Accept asset requests on /ckeditor_assets. Again, this path is
+  # not mandatory. Just be sure to include :job somewhere.
+  url_format "/uploads/ckeditor/:job/:basename.:format"
 end
 
-# Insert our Dragonfly "app" into the stack.
-Rails.application.middleware.insert_after Rack::Cache, Dragonfly::Middleware, :ckeditor
+Rails.application.middleware.use Dragonfly::Middleware, :ckeditor

--- a/test/models/picture_test.rb
+++ b/test/models/picture_test.rb
@@ -11,7 +11,12 @@ class PictureTest < ActiveSupport::TestCase
     assert_equal "image/png", @picture.data_content_type
     assert_equal "rails.png", @picture.data_file_name
     assert_equal 6646, @picture.data_file_size
-    assert @picture.url_thumb.include?('thumb_rails.png')
+
+    if CKEDITOR_BACKEND == :dragonfly
+      assert @picture.url_thumb.include?('thumb_rails')
+    else
+      assert @picture.url_thumb.include?('thumb_rails.png')
+    end
 
     if @picture.has_dimensions?
       assert_equal 50, @picture.width


### PR DESCRIPTION
The generator files and the Dragonfly backend were updated / refactored to conform with Dragonfly's stable API (>= 1.0).

Note that Dragonfly's format validation only works on images, so I had to change the :format validation to :ext validation in the AttachmentFile model. The Picture model is still validating the format.

I really don't know if format validation worked on non image files before 1.0, but now Dragonfly tries to run the "identify" ImageMagick command on these files when you query the "format" attribute of the data file accessor:

```ruby
Ckeditor::AttachmentFile.first.data.format
# DRAGONFLY: shell command: 'identify' '-ping' '-format' '%m %w %h'
# Dragonfly::Shell::CommandFailed: Command failed ('identify' '-ping' '-format' '%m %w %h' '/Users/thiago/Code/ruby/ckeditor_test/public/uploads/ckeditor/development/2015/01/28/4qpavppfmi_macros.pdf') with exit status 1 and stderr
```

I could certainly validate the format using something else, such as a gem or the Unix "file" command, but it would add more (unrelated) code to maintain in the ckeditor gem, which I think is out of scope.

Anyway, I think it's OK to just check the extension.

I'll be happy to work on any issues related to this PR.