### PR TITLE
Bugfix and improve rake task.

### DIFF
--- a/lib/ckeditor.rb
+++ b/lib/ckeditor.rb
@@ -58,6 +58,10 @@ module Ckeditor
   mattr_accessor :assets
   @@assets = nil
 
+  # Remove digest from ckeditor asset files while running assets:precompile task?
+  mattr_accessor :run_on_precompile
+  @@run_on_precompile = true
+
   # Turn on/off filename parameterize
   mattr_accessor :parameterize_filenames
   @@parameterize_filenames = true
@@ -100,6 +104,10 @@ module Ckeditor
   # All css and js files from ckeditor folder
   def self.assets
     @@assets ||= Utils.select_assets("ckeditor", "vendor/assets/javascripts") << "ckeditor/init.js"
+  end
+
+  def self.run_on_precompile?
+    @@run_on_precompile
   end
 
   def self.picture_model(&block)

--- a/lib/tasks/ckeditor.rake
+++ b/lib/tasks/ckeditor.rake
@@ -1,13 +1,26 @@
 require 'fileutils'
 
-desc "Create nondigest versions of all ckeditor digest assets"
-task "assets:precompile" do
-  fingerprint = /\-[0-9a-f]{64}\./
-  for file in Dir["public/assets/ckeditor/**/*"]
-    next unless file =~ fingerprint
-    nondigest = file.sub fingerprint, '.'
-    if !File.exist?(nondigest) or File.mtime(file) > File.mtime(nondigest)
-      FileUtils.cp file, nondigest, verbose: true, preserve: true
+namespace "ckeditor" do
+  desc "Create nondigest versions of all ckeditor digest assets"
+  task "nondigest" => [:environment] do
+    fingerprint = /\-[0-9a-f]{32,64}\./
+    path        = File.join Rails.root.to_s, "public", Ckeditor.base_path, "**/*"
+    files       = Dir[path]
+
+    for file in files
+      next unless file =~ fingerprint
+      nondigest = file.sub fingerprint, '.'
+
+      if !File.exist?(nondigest) or File.mtime(file) > File.mtime(nondigest)
+        FileUtils.cp file, nondigest, verbose: true, preserve: true
+      end
     end
+  end
+end
+
+# Based on rake task from asset_sync gem
+if Rake::Task.task_defined?("assets:precompile")
+  Rake::Task["assets:precompile"].enhance do
+    Rake::Task["ckeditor:nondigest"].invoke if defined?(Ckeditor) && Ckeditor.run_on_precompile?
   end
 end

--- a/test/ckeditor_test.rb
+++ b/test/ckeditor_test.rb
@@ -79,6 +79,12 @@ class CkeditorTest < ActiveSupport::TestCase
     assert_equal Ckeditor.assets.include?('ckeditor/plugins/image/dialogs/image.js'), true
   end
 
+  test 'configuration specifying running ckeditor:nondigest task on assets:precompile' do
+    assert_equal Ckeditor.run_on_precompile?, true
+    Ckeditor.run_on_precompile = false
+    assert_equal Ckeditor.run_on_precompile?, false
+  end
+
   class CustomPicture; end
   class CustomAttachmentFile; end
 end


### PR DESCRIPTION
There were 2 issues regardless this rake task.

First one is about using assets path. It didn't took into consideration assets.prefix path, it was hard coded as "/assets". This resulted in ckeditor assets not being found. Now we use `Ckeditor.base_path` (which uses `assets.prefix` or `Ckeditor.asset_path` if it was set). Besides that we ensure that we are fetching files from within `Rails.root` path.

Second issue is about the way this task was appended to `asset:precompile`.

1. We need a separate task from within assets:precompile to standalone task
2. `Rake::Task#enhance` should be used to append it
3. Add configuration option if we want to run this task by hand

The separate task is mainly because of possible "race conditions" when used with i.e. asset_sync gem combination, which is appending it's own task as well to `assets:precompile` to push assets to CDN. When both gems are appending it's tasks, we can't control the order in which they run, and we need to ensure that ckeditor task needs to run first. So while having a separate rake task `ckeditor:nondigest` we can specify which task should run when, i.e.: `rake assets:precompile ckeditor:nondigest assets:sync`

Related: #537 #522 #507 
Could be related: #469 