### PR TITLE
Ensure that full filenames can be seen.

### DIFF
--- a/app/assets/javascripts/ckeditor/filebrowser/stylesheets/uploader.css.erb
+++ b/app/assets/javascripts/ckeditor/filebrowser/stylesheets/uploader.css.erb
@@ -26,7 +26,7 @@ img {
 	top: 0;
 }
 .gal-holder .gal-item .gal-del:hover {
-	-moz-opacity: 0.7; 
+	-moz-opacity: 0.7;
 	-khtml-opacity: 0.7;
 	opacity: 0.7;
 }
@@ -84,6 +84,10 @@ img {
 	font-size: 12px;
 	overflow: hidden;
 	width: 500px;
+}
+.img-name {
+	word-wrap: break-word;
+	width: auto !important;
 }
 .gal-holder .gal-item .gal-inner-holder .img-data .time-size {
 	display: block;


### PR DESCRIPTION
Hi @galetahub,

Originally it was hard to discern files from one another once the library got quite large and the file name are long:

![image](https://cloud.githubusercontent.com/assets/1248744/6632025/9a1a3b76-c994-11e4-9b8d-3e94584d60cc.png)

I have added a small bit of CSS that will allow the full filename to display by wrapping it and changing the `width` to `auto` on the `img-data`, which now looks like this:

![image](https://cloud.githubusercontent.com/assets/1248744/6632048/ea7d40c2-c994-11e4-86fe-4b71204ff0ad.png)