### PR TITLE
Fix problem with the length of assets' fingerprint when copy to nondigest assets

### DIFF
--- a/lib/tasks/ckeditor.rake
+++ b/lib/tasks/ckeditor.rake
@@ -2,7 +2,7 @@ require 'fileutils'
 
 desc "Create nondigest versions of all ckeditor digest assets"
 task "assets:precompile" do
-  fingerprint = /\-[0-9a-f]{32}\./
+  fingerprint = /\-[0-9a-f]{64}\./
   for file in Dir["public/assets/ckeditor/**/*"]
     next unless file =~ fingerprint
     nondigest = file.sub fingerprint, '.'


### PR DESCRIPTION
In Rails 4.2, the length fingerprint of compiled asset is 64