### PR TITLE
fix css for image blocks in Filebrowser

### DIFF
--- a/app/assets/javascripts/ckeditor/filebrowser/stylesheets/uploader.css.erb
+++ b/app/assets/javascripts/ckeditor/filebrowser/stylesheets/uploader.css.erb
@@ -11,10 +11,12 @@ img {
 	overflow: hidden;
 	padding: 20px;
 }
+.gal-holder .gal-item:first-child {
+    float: left;
+}
 .gal-holder .gal-item {
-	display: block;
-	float: left;
-	width: 150px;
+    display: inline-block;
+    width: 150px;
 	overflow: hidden;
 	position: relative;
 	margin: 0 12px 12px 0;


### PR DESCRIPTION
Arrange image blocks in filebrowser then long filenames change block height.

Before fix:
![Before fix](https://leto46h.storage.yandex.net/rdisk/a3ebcb7e052729aa934c0ccdb897253248b368e09a5b230786f7195e075e8983/inf/LI4rnJsuNEIYo5yuSJoue8AazpFXL8Zb6wrFRpQ6WGK-SaOMCHgoaCExI2tAtVQP9MJpAZVuyiu1nFrE_bP1ow==?uid=0&filename=2015-05-27%2013-34-03%20%D0%A0%D0%B0%D0%B1%D0%BE%D1%87%D0%B8%D0%B9%20%D1%81%D1%82%D0%BE%D0%BB.png&disposition=inline&hash=&limit=0&content_type=image%2Fpng&tknv=v2&rtoken=522143116b9edc5d7ea9910df88beb3a&force_default=no)

After fix:
![After fix](https://leto25f.storage.yandex.net/rdisk/56d54135df02e3fec9bb6974b1f73864b8bc6d7e653d9456dc5d7034c8e3fa09/inf/eFMkXsgyoTMF29NdulUm6hGXpxhUDpONfdOnFRmHQYuWGK8-5G4aHgu5-F12vEVs8PMH4YJ5wh_77agMKSLkpA==?uid=0&filename=2015-05-27%2013-28-44%20%D0%A0%D0%B0%D0%B1%D0%BE%D1%87%D0%B8%D0%B9%20%D1%81%D1%82%D0%BE%D0%BB.png&disposition=inline&hash=&limit=0&content_type=image%2Fpng&tknv=v2&rtoken=522143116b9edc5d7ea9910df88beb3a&force_default=no)