### PR TITLE
Update _asset.html.erb

### DIFF
--- a/app/views/ckeditor/shared/_asset.html.erb
+++ b/app/views/ckeditor/shared/_asset.html.erb
@@ -1,7 +1,7 @@
 <%= content_tag(:div, :id => dom_id(asset), :class => "gal-item", :"data-url" => image_path(asset.url_content)) do %>
   <%= link_to image_tag('ckeditor/filebrowser/images/gal_del.png',
     :title => I18n.t('ckeditor.buttons.delete')),
-          polymorphic_path(asset, :format => :json),
+          image_path(asset.url_content),
           :remote => true,
           :method => :delete, 
           :data => {:confirm => t('ckeditor.confirm_delete')},

--- a/app/views/ckeditor/shared/_asset.html.erb
+++ b/app/views/ckeditor/shared/_asset.html.erb
@@ -1,7 +1,7 @@
 <%= content_tag(:div, :id => dom_id(asset), :class => "gal-item", :"data-url" => image_path(asset.url_content)) do %>
   <%= link_to image_tag('ckeditor/filebrowser/images/gal_del.png',
     :title => I18n.t('ckeditor.buttons.delete')),
-          image_path(asset.url_content),
+          picture_path(asset),
           :remote => true,
           :method => :delete, 
           :data => {:confirm => t('ckeditor.confirm_delete')},


### PR DESCRIPTION
I [change][1] class Pictury to class Ckeditor::Epicture < Ckeditor::Asset
and from editor picture browser (.../ckeditor/pictures?CKEditor=memory_about&CKEditorFuncNum=1&langCode=ru) was an error:

NoMethodError in Ckeditor/pictures#index Showing /usr/local/rvm/gems/ruby-1.9.3-p545/gems/ckeditor-4.1.0/app/views/ckeditor/shared/_asset.html.erb where line #4 raised: undefined method 'epicture_path' for #<#<Class:0x00000005a652e8>:0x0000000799b158> Extracted source (around line #4): 1: <%= content_tag(:div, :id => dom_id(asset), :class => "gal-item", :"data-url" => image_path(asset.url_content)) do %> 2: <%= link_to image_tag('ckeditor/filebrowser/images/gal_del.png', 3: :title => I18n.t('ckeditor.buttons.delete')), 4: polymorphic_path(asset, :format => :json), 5: :remote => true, 6: :method => :delete, 7: :data => {:confirm => t('ckeditor.confirm_delete')}

For correct work in _asset.html.erb I change:

polymorphic_path(asse, :format => :json) to image_path(asset.url_content)

And works it fine.
Please fix in gem. Thanks

[1]: http://stackoverflow.com/a/31070828/3563993