### PR TITLE
Support drag&drop image upload by JSON response

### DIFF
--- a/app/controllers/ckeditor/pictures_controller.rb
+++ b/app/controllers/ckeditor/pictures_controller.rb
@@ -1,4 +1,5 @@
 class Ckeditor::PicturesController < Ckeditor::ApplicationController
+  skip_before_action :verify_authenticity_token, only: :create # FIXME: this should go away
 
   def index
     @pictures = Ckeditor.picture_adapter.find_all(ckeditor_pictures_scope)


### PR DESCRIPTION
Uploading pasted and dragged images was introduced in CKEditor 4.5
(provided through an optional Upload Image)

See more:
http://docs.ckeditor.com/#!/guide/dev_file_upload
http://ckeditor.com/addon/uploadimage

And you have to define this in config.js:
config.imageUploadUrl = "/ckeditor/pictures?responseType=json";

It works smoothly then.

Current known issue:
pictures#create skips CSRF verification for now

What do you think guys? Anyway we have to clean controller action I think and implement CSRF verification.