### PR TITLE
fixing issue with pagination (route not found)

### DIFF
--- a/app/views/ckeditor/attachment_files/index.html.erb
+++ b/app/views/ckeditor/attachment_files/index.html.erb
@@ -4,14 +4,14 @@
   		<%= link_to I18n.t(:upload, :scope => [:ckeditor, :buttons]), 'javascript:void(0)', :class => "add" %>
 		</div>
 	</div>
-  
+
   <div class="fileupload-list">
-    <%= render :partial => 'ckeditor/shared/asset', :collection => @attachments.scoped %>		
+    <%= render :partial => 'ckeditor/shared/asset', :collection => @attachments.scoped %>
   </div>
 
   <% unless @attachments.last_page? %>
     <div class="pagination">
-      <%= link_to I18n.t("ckeditor.buttons.next"), params.merge(:page => @attachments.next_page), :class => "next", :rel => "next" %>
+      <%= link_to I18n.t("ckeditor.buttons.next"), ckeditor.attachment_files_path(params.merge(:page => @attachments.next_page)), :class => "next", :rel => "next" %>
     </div>
   <% end -%>
 

--- a/app/views/ckeditor/pictures/index.html.erb
+++ b/app/views/ckeditor/pictures/index.html.erb
@@ -4,14 +4,14 @@
   		<%= link_to I18n.t(:upload, :scope => [:ckeditor, :buttons]), 'javascript:void(0)', :class => "add" %>
 		</div>
 	</div>
-  
+
   <div class="fileupload-list" data-endless="true">
-    <%= render :partial => 'ckeditor/shared/asset', :collection => @pictures.scoped %>		
+    <%= render :partial => 'ckeditor/shared/asset', :collection => @pictures.scoped %>
   </div>
 
   <% unless @pictures.last_page? %>
     <div class="pagination">
-      <%= link_to I18n.t("ckeditor.buttons.next"), params.merge(:page => @pictures.next_page), :class => "next", :rel => "next" %>
+      <%= link_to I18n.t("ckeditor.buttons.next"), ckeditor.pictures_path(params.merge(:page => @pictures.next_page)), :class => "next", :rel => "next" %>
     </div>
   <% end -%>
 


### PR DESCRIPTION
Fixing issue with:

ActionView::Template::Error (No route matches {:CKEditor=>"page_content", :CKEditorFuncNum=>"1", :action=>"index", :controller=>"ckeditor/pictures", :langCode=>"en", :page=>2}):
    11:
    12:   <% unless @pictures.last_page? %>
    13:     <div class="pagination">
    14:       <%= link_to I18n.t("ckeditor.buttons.next"), params.merge(:page => @pictures.next_page), :class => "next", :rel => "next" %>
    15:     </div>
    16:   <% end -%>
    17:
  actionpack (4.2.4) lib/action_dispatch/journey/formatter.rb:46:in `generate'
  actionpack (4.2.4) lib/action_dispatch/routing/route_set.rb:729:in `generate'
  actionpack (4.2.4) lib/action_dispatch/routing/route_set.rb:760:in `generate'
  actionpack (4.2.4) lib/action_dispatch/routing/route_set.rb:803:in `url_for'
  actionpack (4.2.4) lib/action_dispatch/routing/url_for.rb:156:in `url_for'
  actionview (4.2.4) lib/action_view/routing_url_for.rb:94:in `url_for'
  actionview (4.2.4) lib/action_view/helpers/url_helper.rb:181:in `link_to'
  ckeditor (4.1.3) app/views/ckeditor/pictures/index.html.erb:14:in `___sers_igorkasyanchuk__rvm_gems_ruby_______gems_ckeditor_______app_views_ckeditor_pictures_index_html_erb___4085009171501430203_70262953988060'
  actionview (4.2.4) lib/action_view/template.rb:145:in `block in render'
  activesupport (4.2.4) lib/active_support/notifications.rb:166:in `instrument'
