### PR TITLE
Add Bulgarian translation

### DIFF
--- a/config/locales/bg.ckeditor.yml
+++ b/config/locales/bg.ckeditor.yml
@@ -1,0 +1,9 @@
+bg:
+  ckeditor:
+    page_title: "Списък с файлове"
+    confirm_delete: "Сигурни ли сте, че искате да изтриете този файл?"
+    buttons:
+      cancel: "Откажи"
+      upload: "Качи"
+      delete: "Изтрий"
+      next: "Следващ"


### PR DESCRIPTION
Why:

* The BG locale translation was missing

This change addresses the need by:

* Adding translation yml for bg locale