### PR TITLE
Fix css for file browser

### DIFF
--- a/app/assets/javascripts/ckeditor/filebrowser/stylesheets/uploader.css.erb
+++ b/app/assets/javascripts/ckeditor/filebrowser/stylesheets/uploader.css.erb
@@ -3,41 +3,57 @@ body {
 	margin: 0;
 	font-family: Arial, Helvetica, sans-serif;
 }
+
 img {
   border: 0;
 }
+
 .gal-holder {
 	display: block;
 	overflow: hidden;
 	padding: 20px;
 }
-.gal-holder .gal-item:first-child {
-    float: left;
+
+.gal-item .gal-new-upload {
+	display: block;
+	float: left;
 }
+
+.gal-holder .gal-item:first-child {
+  float: left;
+}
+
 .gal-holder .gal-item {
-    display: inline-block;
-    width: 150px;
+	float: none;
+  display: inline-block;
+  width: 150px;
 	overflow: hidden;
 	position: relative;
 	margin: 0 12px 12px 0;
+	vertical-align: top;
 }
+
 .gal-holder .gal-item .gal-del {
 	display: block;
 	position: absolute;
 	right: 0;
 	top: 0;
 }
+
 .gal-holder .gal-item .gal-del:hover {
 	-moz-opacity: 0.7;
 	-khtml-opacity: 0.7;
 	opacity: 0.7;
 }
+
 .gal-holder .gal-item .gal-upload-holder input {
 	height: 162px;
 }
+
 .gal-holder .gal-item .gal-upload-holder .add:hover {
 	text-decoration: underline;
 }
+
 .gal-holder .gal-item .gal-inner-holder, .gal-holder .gal-item .gal-upload-holder {
 	display: block;
 	margin: 6px 6px 0 0;
@@ -47,14 +63,16 @@ img {
 	border: solid 1px #D3D3D3;
 	min-height: 138px;
 }
+
 .gal-holder .gal-item .gal-inner-holder.hover {
     background: #DFF1FF;
     border: solid 1px #99CCFF;
 }
 .gal-holder .gal-item .gal-inner-holder.selected {
-    background: #B4D9FF;
-    border: solid 1px #6565FE;
+  background: #B4D9FF;
+  border: solid 1px #6565FE;
 }
+
 .gal-holder .gal-item .gal-upload-holder .add {
   display: block;
   color: #2e5aff;
@@ -65,20 +83,24 @@ img {
   margin: 50px 0 0 10px;
   font-size: 14px;
 }
+
 .gal-holder .gal-item .gal-inner-holder .img {
 	height: 100px;
 	overflow: hidden;
 	cursor:pointer;
 }
+
 .gal-holder .gal-item .gal-inner-holder .img.preloader {
 	padding: 27px 0 0 33px;
 	height: 73px;
 }
+
 .gal-holder .gal-item .gal-inner-holder .img-data {
 	display: block;
 	overflow: hidden;
 	padding-top: 5px;
 }
+
 .gal-holder .gal-item .gal-inner-holder .img-data .img-name {
 	display: block;
 	color: #333;
@@ -87,24 +109,29 @@ img {
 	overflow: hidden;
 	width: 500px;
 }
+
 .img-name {
 	word-wrap: break-word;
 	width: auto !important;
 }
+
 .gal-holder .gal-item .gal-inner-holder .img-data .time-size {
 	display: block;
 	overflow: hidden;
 	font-size: 10px;
 	color: #666;
 }
+
 .gal-holder .gal-item .gal-inner-holder .img-data .time-size .time {
 	display: block;
 	float: left;
 }
+
 .gal-holder .gal-item .gal-inner-holder .img-data .time-size .size {
 	display: block;
 	float: right;
 }
+
 .gal-more {
 	display: block;
 	overflow: hidden;
@@ -112,6 +139,7 @@ img {
 	padding: 20px 0;
 	text-align: center;
 }
+
 .gal-more a {
 	color: #2e5aff;
 	background: url(<%= asset_path('ckeditor/filebrowser/images/gal_more.gif') %>) no-repeat left center;
@@ -119,6 +147,7 @@ img {
 	font-size: 14px;
 	text-decoration: none;
 }
+
 .gal-more a:hover {
 	text-decoration: underline;
 }

--- a/app/views/ckeditor/attachment_files/index.html.erb
+++ b/app/views/ckeditor/attachment_files/index.html.erb
@@ -1,5 +1,5 @@
 <div id="fileupload" class="gal-holder">
-  <div class="gal-item">
+  <div class="gal-item gal-new-upload">
     <div class="fileupload-button gal-upload-holder">
   		<%= link_to I18n.t(:upload, :scope => [:ckeditor, :buttons]), 'javascript:void(0)', :class => "add" %>
 		</div>


### PR DESCRIPTION
File browser previews should now align nicely

<img width="982" alt="screen shot 2015-11-03 at 9 27 28 am" src="https://cloud.githubusercontent.com/assets/7959274/10893328/213b1fd6-820d-11e5-8aa8-c2733b5cd420.png">
