### PR TITLE
make the controller that ckeditor inherits from configurable

### DIFF
--- a/app/controllers/ckeditor/application_controller.rb
+++ b/app/controllers/ckeditor/application_controller.rb
@@ -1,4 +1,4 @@
-class Ckeditor::ApplicationController < ApplicationController
+class Ckeditor::ApplicationController < Ckeditor.parent_controller.constantize
   layout 'ckeditor/application'
 
   before_filter :find_asset, :only => [:destroy]

--- a/lib/ckeditor.rb
+++ b/lib/ckeditor.rb
@@ -90,6 +90,10 @@ module Ckeditor
   @@picture_model = nil
   @@attachment_file_model = nil
 
+  # Configurable parent controller
+  mattr_accessor :parent_controller
+  @@parent_controller = 'ApplicationController'
+
   # Default way to setup Ckeditor. Run rails generate ckeditor to create
   # a fresh initializer with all configuration values.
   #


### PR DESCRIPTION
I found myself in a situation where there is no `ApplicationController` in my app (I am developing an admin engine, which requires app to have `MyEngine::Frontend::ApplicationController` and itself provides `MyEngine::Admin::ApplicationController`. Creating an empty `ApplicationController` causes some weird scoping issues. I believe that the ability to configure parent controller for ckeditor will be useful for other users as well.