### PR TITLE
Update docs with parent_controller configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,17 @@ By default, only the user that logged in can access the models (with actions *in
 
 You can customize these two policy files as you like.
 
+## Engine configuration
+ * To override the default CKEditor routes create a [config.js](https://github.com/galetahub/ckeditor/blob/master/app/assets/javascripts/ckeditor/config.js) file within the host application at `app/assets/javascripts/ckeditor/config.js`
+ * To override the default parent controller
+```
+# in config/initializers/ckeditor.rb
+
+Ckeditor.setup do |config|
+  config.parent_controller = 'MyController'
+end
+```
+
 ## I18n
 
 ```yml

--- a/lib/generators/ckeditor/templates/ckeditor.rb
+++ b/lib/generators/ckeditor/templates/ckeditor.rb
@@ -20,6 +20,10 @@ Ckeditor.setup do |config|
   # By default: there is no authorization.
   # config.authorize_with :cancan
 
+  # Override parent controller CKEditor inherits from
+  # By default: 'ApplicationController'
+  # config.parent_controller = 'MyController'
+
   # Asset model classes
   # config.picture_model { Ckeditor::Picture }
   # config.attachment_file_model { Ckeditor::AttachmentFile }


### PR DESCRIPTION
The [feature](https://github.com/galetahub/ckeditor/pull/636) @danpecher added to configure the parent controller is really useful but took a while to find so i've added some docs to the README and default initialiser. 

I also added a note on the README about how to override the default CKEditor routes as its been [asked](https://github.com/galetahub/ckeditor/issues/610) a couple of times now.

Be great to get a new release with the new `parent_controller` configurable and the other things that have gone in since the last.