### PR TITLE
assets:precompile isn't copying html files in ckeditor plugins in production mode

### DIFF
--- a/lib/ckeditor/utils.rb
+++ b/lib/ckeditor/utils.rb
@@ -70,7 +70,7 @@ module Ckeditor
       def select_assets(path, relative_path)
         relative_folder = Ckeditor.root_path.join(relative_path)
         folder = relative_folder.join(path)
-        extensions = '*.{js,css,png,gif,jpg}'
+        extensions = '*.{js,css,png,gif,jpg,html}'
         languages = (Ckeditor.assets_languages || [])
 
         # Files at root


### PR DESCRIPTION
While using this gem in production mode with nginx serving static assets, we're getting 404 error for html files in ckeditor plugins. An example is "vendor/assets/javascripts/ckeditor/plugins/wsc/dialogs/tmp.html" or "vendor/assets/javascripts/ckeditor/plugins/wsc/dialogs/tmpFrameset.html" isn't being copied to public/assets. This in turn breaking ckeditor spellcheck functionality for us.

Looks like ckeditor plugin static assets have html files too. This pull request includes html files in assets:precompile path.

Please let me know if anyone is seeing this problem or if there's any other solution.