### PR TITLE
Return relative or absolute URL as asset response

### DIFF
--- a/lib/ckeditor/asset_response.rb
+++ b/lib/ckeditor/asset_response.rb
@@ -30,7 +30,7 @@ module Ckeditor
       elsif ckeditor?
         {
           text: %Q"<script type='text/javascript'>
-            window.parent.CKEDITOR.tools.callFunction(#{params[:CKEditorFuncNum]}, '#{relative_url_root}#{Ckeditor::Utils.escape_single_quotes(asset.url_content)}');
+            window.parent.CKEDITOR.tools.callFunction(#{params[:CKEditorFuncNum]}, '#{asset_url(relative_url_root)}');
           </script>"
         }
       else
@@ -53,6 +53,18 @@ module Ckeditor
         }
       else
         {nothing: true, format: :json}
+      end
+    end
+
+    private
+
+    def asset_url(relative_url_root)
+      url = Ckeditor::Utils.escape_single_quotes(asset.url_content)
+
+      if URI(url).relative?
+        "#{relative_url_root}#{url}"
+      else
+        url
       end
     end
   end


### PR DESCRIPTION
If the application using the editor is [deployed to a subdirectory](http://guides.rubyonrails.org/configuring.html#deploy-to-a-subdirectory-relative-url-root) such as _“/blog”_,  the [Ckeditor::ApplicationController](https://github.com/galetahub/ckeditor/blob/0ebc23b5c512b1ceb6de58a2616cacf25ec5c2f6/app/controllers/ckeditor/application_controller.rb#L15) passes this along to `AssetResponse` which always prepends the `relative_url_root` whether the uploaded asset's URL is relative or not. This doesn't play well if the image is uploaded to a CDN.

![911ffdc0-243e-11e6-8246-a27d2f1ad305](https://cloud.githubusercontent.com/assets/966819/15677845/e9f6ea8c-2743-11e6-9a6d-1547001bfd02.png)

This little patch adds a private method that checks if the asset's URL is relative or not.

cc: @tomas-stefano