### PR TITLE
fix attachments preview in the file manager

### DIFF
--- a/app/views/ckeditor/attachment_files/index.html.erb
+++ b/app/views/ckeditor/attachment_files/index.html.erb
@@ -6,7 +6,7 @@
 	</div>
 
   <div class="fileupload-list">
-    <%= render :partial => 'ckeditor/shared/asset', :collection => @attachments %>
+    <%= render :partial => 'ckeditor/shared/asset', :collection => @attachments.scoped %>
   </div>
 
   <% unless @attachments.last_page? %>


### PR DESCRIPTION
Hey,  
Browsing files (attachments only) in the ck file manager isn't available because collection isn't scoped.
