### PR TITLE
Rails.root.join wrong usage

### DIFF
--- a/lib/tasks/ckeditor.rake
+++ b/lib/tasks/ckeditor.rake
@@ -4,7 +4,7 @@ namespace :ckeditor do
   desc 'Create nondigest versions of all ckeditor digest assets'
   task nondigest: :environment do
     fingerprint = /\-[0-9a-f]{32,64}\./
-    path = Rails.root.join('public', Ckeditor.base_path, '**/*')
+    path = Rails.root.join("public#{Ckeditor.base_path}**/*")
 
     Dir[path].each do |file|
       next unless file =~ fingerprint


### PR DESCRIPTION
Nondigest files not copied on production. Rails.root.join can't paths like '/assets/ckeditor/'. No subdirectories.