### PR TITLE
Correct example config change

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ CKEDITOR.editorConfig = function (config) {
   config.toolbar_mini = [
     ["Bold",  "Italic",  "Underline",  "Strike",  "-",  "Subscript",  "Superscript"],
   ];
-  config.toolbar = "simple";
+  config.toolbar = "Mini"; // name of config using initial capital
 
   // ... rest of the original config.js  ...
 }


### PR DESCRIPTION
The config override selection needs to be the name of the config, capitalized.

So that toolbar_myconfig would become 'Myconfig'.