### PR TITLE
Fix typo and add note in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ CKEDITOR.editorConfig = function (config) {
   config.toolbar_mini = [
     ["Bold",  "Italic",  "Underline",  "Strike",  "-",  "Subscript",  "Superscript"],
   ];
-  config.toolbar = "simple";
+  config.toolbar = "mini";
 
   // ... rest of the original config.js  ...
 }
@@ -256,6 +256,9 @@ jQuery sample:
 ```
 
 ### SimpleForm integration
+Note that the toolbar option should match the case specified in the config. If the config is not found it defaults to all available toolbar items. 
+
+i.e. config.toolbar_mini becomes {toolbar: 'mini'} in the form.
 
 ```slim
 = form.input :content, as: :ckeditor, input_html: { ckeditor: { toolbar: 'Full' } }


### PR DESCRIPTION
The example config should have used the name of the config, and I have added a note about case being important in the helper.

The second of these had me stumped for quite some time...