### PR TITLE
Updating skip_before_action to not raise error if method is not already in filter chain.

### DIFF
--- a/app/controllers/ckeditor/attachment_files_controller.rb
+++ b/app/controllers/ckeditor/attachment_files_controller.rb
@@ -1,5 +1,5 @@
 class Ckeditor::AttachmentFilesController < Ckeditor::ApplicationController
-  skip_before_action :verify_authenticity_token, only: :create
+  skip_before_action :verify_authenticity_token, only: :create, raise: false
 
   def index
     @attachments = Ckeditor.attachment_file_adapter.find_all(ckeditor_attachment_files_scope)

--- a/app/controllers/ckeditor/pictures_controller.rb
+++ b/app/controllers/ckeditor/pictures_controller.rb
@@ -1,5 +1,5 @@
 class Ckeditor::PicturesController < Ckeditor::ApplicationController
-  skip_before_action :verify_authenticity_token, only: :create
+  skip_before_action :verify_authenticity_token, only: :create, raise: false
 
   def index
     @pictures = Ckeditor.picture_adapter.find_all(ckeditor_pictures_scope)


### PR DESCRIPTION
We have an app where, for some external reasons, we are not able to implement `protect_from_forgery` in our ApplicationController.  When upgrading ckeditor, we found that the app would bomb during `eager_load!` with this exception

```
ArgumentError: Before process_action callback :verify_authenticity_token has not been defined
```

because `verify_authenticity_token` isn't added to the filter chain in our case.  

I'm suggesting a small update to not raise an exception for apps that dont use `protect_from_forgery`.  