### PR TITLE
Add ? to filebrowserImageUploadUrl

### DIFF
--- a/app/assets/javascripts/ckeditor/config.js
+++ b/app/assets/javascripts/ckeditor/config.js
@@ -26,7 +26,7 @@ CKEDITOR.editorConfig = function( config )
   config.filebrowserImageBrowseUrl = "/ckeditor/pictures";
 
   // The location of a script that handles file uploads in the Image dialog.
-  config.filebrowserImageUploadUrl = "/ckeditor/pictures";
+  config.filebrowserImageUploadUrl = "/ckeditor/pictures?";
 
   // The location of a script that handles file uploads.
   config.filebrowserUploadUrl = "/ckeditor/attachment_files";


### PR DESCRIPTION
When using uploadimage it adds `&respondeType=json` at the end of `config.filebrowserImageUploadUrl`

See [https://github.com/ckeditor/ckeditor-dev/blob/master/plugins/filetools/plugin.js#L825](https://github.com/ckeditor/ckeditor-dev/blob/master/plugins/filetools/plugin.js#L825)

This change doesn't have any impact for the basic installation but helps a lot when adding the uploadimage plugin.