### PR TITLE
Use addressable gem instead of ruby URI

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     ckeditor (4.2.4)
+      addressable (~> 2.5.1)
       cocaine
       orm_adapter (~> 0.5.0)
 
@@ -222,4 +223,4 @@ DEPENDENCIES
   unicorn (~> 4.0.1)
 
 BUNDLED WITH
-   1.15.0
+   1.15.1

--- a/ckeditor.gemspec
+++ b/ckeditor.gemspec
@@ -21,4 +21,5 @@ Gem::Specification.new do |s|
 
   s.add_dependency("cocaine")
   s.add_dependency("orm_adapter", "~> 0.5.0")
+  s.add_dependency("addressable", "~> 2.5.1")
 end

--- a/lib/ckeditor.rb
+++ b/lib/ckeditor.rb
@@ -1,5 +1,6 @@
 require 'orm_adapter'
 require 'pathname'
+require 'addressable/uri'
 
 module Ckeditor
   autoload :Utils, 'ckeditor/utils'

--- a/lib/ckeditor/asset_response.rb
+++ b/lib/ckeditor/asset_response.rb
@@ -88,7 +88,7 @@ module Ckeditor
     def asset_url(relative_url_root)
       url = Ckeditor::Utils.escape_single_quotes(asset.url_content)
 
-      if URI(url).relative?
+      if Addressable::URI.parse(url).relative?
         "#{relative_url_root}#{url}"
       else
         url


### PR DESCRIPTION
Addressable more closely conforms to RFC 3986, RFC 3987, and RFC 6570 (level 4),
so, e.g., URI with spaces are supported too.