### PR TITLE
Change migration number to UTC time

### DIFF
--- a/lib/generators/ckeditor/install_generator.rb
+++ b/lib/generators/ckeditor/install_generator.rb
@@ -20,7 +20,7 @@ module Ckeditor
       end
 
       def self.next_migration_number(_dirname)
-        Time.now.strftime('%Y%m%d%H%M%S')
+        Time.now.utc.strftime('%Y%m%d%H%M%S')
       end
 
       # copy configuration


### PR DESCRIPTION
I specified migration number to use UTC, making the migration order correct.