### PR TITLE
Call the authorize method on the controller

### DIFF
--- a/lib/ckeditor/hooks/pundit.rb
+++ b/lib/ckeditor/hooks/pundit.rb
@@ -27,7 +27,7 @@ module Ckeditor
       # This takes the same arguments as +authorize+. The difference is that this will
       # return a boolean whereas +authorize+ will raise an exception when not authorized.
       def authorized?(action, model_object = nil)
-        Pundit.policy(@controller.current_user_for_pundit, model_object).public_send(action + '?') if action
+        @controller.authorize(model_object, "#{action}?") if action
       end
 
       module ControllerExtension


### PR DESCRIPTION
This ensure `:verify_authorized` passes successfully when configured in the
controller.

This should solve issue https://github.com/galetahub/ckeditor/issues/609