### PR TITLE
Update README to make it clearer that the engine's controller aren't secure by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,13 +354,25 @@ By default, only the user that logged in can access the models (with actions *in
 You can customize these two policy files as you like.
 
 ## Engine configuration
- * To override the default CKEditor routes create a [config.js](https://github.com/galetahub/ckeditor/blob/master/app/assets/javascripts/ckeditor/config.js) file within the host application at `app/assets/javascripts/ckeditor/config.js`
- * To override the default parent controller
+ 
+* To override the default CKEditor routes create a [config.js](https://github.com/galetahub/ckeditor/blob/master/app/assets/javascripts/ckeditor/config.js) file within the host application at `app/assets/javascripts/ckeditor/config.js`
+
+* By default, the engine inherits from `ApplicationController`. To override the default parent controller:
 ```
 # in config/initializers/ckeditor.rb
 
 Ckeditor.setup do |config|
-  config.parent_controller = 'MyController'
+  config.parent_controller = 'MyCKEditorBaseController'
+end
+```
+
+Based on this, if you want to secure CKEditor controller actions and you can't authenticate in ApplicationController, you could do so with a custom controller after configuring the override above, like so:
+
+```
+class MyCKEditorBaseController < ActionController::Base
+
+  before_action :authenticate_user! # or some other auth/permission logic here, like Pundit
+
 end
 ```
 


### PR DESCRIPTION
By default the gem's controller inherits from ApplicationController, so all it's actions (like listing files/images, deleting, uploading, so on) will be open to everyone, since most likely there won't be auth logic on ApplicationController itself.

This readme improvement makes it clearer that people should create a custom controller and add auth logic there to make their CKEditor engine secure.