### PR TITLE
Switch to CanCanCan

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ CKEditor is a WYSIWYG text editor designed to simplify web content creation. It 
 * Files browser
 * HTML5 file uploader
 * Hooks for formtastic and simple_form forms generators
-* Integrated with authorization framework CanCan and Pundit
+* Integrated with authorization frameworks [CanCanCan](https://github.com/CanCanCommunity/cancancan) and [Pundit](https://github.com/varvet/pundit)
 
 ## Installation
 
@@ -306,7 +306,7 @@ $(document).on('page:load', ready)
 ```
 Make sure the file is loaded from your app/assets/javascripts/application.js
 
-### CanCan integration
+### CanCanCan integration
 
 To use cancan with Ckeditor, add this to an initializer:
 
@@ -314,12 +314,12 @@ To use cancan with Ckeditor, add this to an initializer:
 # in config/initializers/ckeditor.rb
 
 Ckeditor.setup do |config|
-  config.authorize_with :cancan
+  config.authorize_with :cancancan
 end
 ```
 
 At this point, all authorization will fail and no one will be able to access the filebrowser pages.
-To grant access, add this to Ability#initialize:
+To grant access, add the following abilities (usually `ability.rb`)
 
 ```ruby
 # Always performed
@@ -332,7 +332,7 @@ can [:read, :create, :destroy], Ckeditor::AttachmentFile
 
 ### Pundit integration
 
-Just like CanCan, you can write this code in your config/initializers/ckeditor.rb file:
+Just like CanCanCan, you can write this code in your config/initializers/ckeditor.rb file:
 
 ```ruby
 Ckeditor.setup do |config|

--- a/lib/ckeditor.rb
+++ b/lib/ckeditor.rb
@@ -201,11 +201,11 @@ module Ckeditor
   #   end
   #
   # To use an authorization adapter, pass the name of the adapter. For example,
-  # to use with CanCan[https://github.com/ryanb/cancan], pass it like this.
+  # to use with CanCanCan[https://github.com/CanCanCommunity/cancancan], pass it like this.
   #
-  # @example CanCan
+  # @example CanCanCan
   #   Ckeditor.setup do |config|
-  #     config.authorize_with :cancan
+  #     config.authorize_with :cancancan
   #   end
   #
   def self.authorize_with(*args, &block)

--- a/lib/ckeditor/hooks/cancan.rb
+++ b/lib/ckeditor/hooks/cancan.rb
@@ -2,7 +2,7 @@ require 'cancan'
 
 module Ckeditor
   module Hooks
-    # This adapter is for the CanCan[https://github.com/ryanb/cancan] authorization library.
+    # This adapter is for the CanCanCan[https://github.com/CanCanCommunity/cancancan] authorization library.
     # You can create another adapter for different authorization behavior, just be certain it
     # responds to each of the public methods here.
     class CanCanAuthorization
@@ -45,3 +45,4 @@ module Ckeditor
 end
 
 Ckeditor::AUTHORIZATION_ADAPTERS[:cancan] = Ckeditor::Hooks::CanCanAuthorization
+Ckeditor::AUTHORIZATION_ADAPTERS[:cancancan] = Ckeditor::Hooks::CanCanAuthorization

--- a/lib/generators/ckeditor/templates/ckeditor.rb
+++ b/lib/generators/ckeditor/templates/ckeditor.rb
@@ -23,7 +23,7 @@ Ckeditor.setup do |config|
 
   # Setup authorization to be run as a before filter
   # By default: there is no authorization.
-  # config.authorize_with :cancan
+  # config.authorize_with :cancancan
 
   # Override parent controller CKEditor inherits from
   # By default: 'ApplicationController'


### PR DESCRIPTION
CanCan project is deprecated since six years. This PR allows to use both `cancan` and `cancancan` and updates the README to point to the currently maintained version of the gem