### PR TITLE
Fix crash on "upload file" on 3rd tab "Upload"

### DIFF
--- a/lib/ckeditor/http.rb
+++ b/lib/ckeditor/http.rb
@@ -73,12 +73,14 @@ module Ckeditor
     # Convert nested Hash to HashWithIndifferentAccess and replace
     # file upload hash with UploadedFile objects
     def self.normalize_param(*args)
-      value = args.first
+      value = args.compact.first
 
       if value.is_a?(Hash) && value.key?(:tempfile)
         UploadedFile.new(value)
       elsif value.is_a?(String)
         QqFile.new(*args)
+      elsif value.is_a?(ActionDispatch::Request)
+        value.params['upload']
       else
         value
       end


### PR DESCRIPTION
Fix crash on this page: http://prntscr.com/n2uq4t (send it to the server on CKEditor upload tab)

Plus it might be useful to put in config.js of editor:
config.filebrowserImageUploadUrl = "/ckeditor/pictures?type=Images?command=QuickUpload";

so it will not show JS alert of "undefined".