### PR TITLE
Set config.filebrowserUploadMethod to "form"

### DIFF
--- a/app/assets/javascripts/ckeditor/config.js
+++ b/app/assets/javascripts/ckeditor/config.js
@@ -32,6 +32,7 @@ CKEDITOR.editorConfig = function( config )
   config.filebrowserUploadUrl = "/ckeditor/attachment_files";
 
   config.allowedContent = true;
+  config.filebrowserUploadMethod = 'form';
 
   // Toolbar groups configuration.
   config.toolbar = [


### PR DESCRIPTION
- CKEditor 4.9 introduced "xhr" file uploads and also made it default
- config.filebrowserUploadMethod needs to be explicitly set as "form"
  for URL query params to function the same as pre-4.9 CKEditor
- Docs for this param:
  - https://github.com/galetahub/ckeditor/blob/74c188c5bb7197c67197272f55951ca1c0864cda/vendor/assets/javascripts/ckeditor/CHANGES.md#ckeditor-49
  - https://github.com/ckeditor/ckeditor-dev/issues/1365
  - https://github.com/ckeditor/ckeditor-dev/pull/1507/commits/4e0866c877dde58247ff5042c10a8ad3ecb0a13f

Default config fix for https://github.com/galetahub/ckeditor/issues/829