### PR TITLE
Add shrine backend

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,5 +29,8 @@ platforms :ruby do
     gem 'carrierwave-mongoid', require: 'carrierwave/mongoid'
     gem 'mongoid', '~> 7.0.2'
     gem 'mongoid-paperclip', require: 'mongoid_paperclip'
+    gem 'shrine'
+    gem 'shrine-mongoid'
+    gem 'image_processing'
   end
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,7 +72,10 @@ GEM
       mongoid-grid_fs (>= 1.3, < 3.0)
     climate_control (0.2.0)
     concurrent-ruby (1.1.5)
+    content_disposition (1.0.0)
     crass (1.0.4)
+    down (4.8.1)
+      addressable (~> 2.5)
     dragonfly (1.2.0)
       addressable (~> 2.3)
       multi_json (~> 1.0)
@@ -83,6 +86,9 @@ GEM
       activesupport (>= 4.2.0)
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
+    image_processing (1.9.1)
+      mini_magick (>= 4.9.3, < 5)
+      ruby-vips (>= 2.0.13, < 3)
     jquery-rails (4.3.3)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
@@ -164,11 +170,19 @@ GEM
     rb-inotify (0.10.0)
       ffi (~> 1.0)
     regexp_parser (1.3.0)
+    ruby-vips (2.0.14)
+      ffi (~> 1.9)
     sass (3.7.3)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
+    shrine (2.19.3)
+      content_disposition (~> 1.0)
+      down (~> 4.1)
+    shrine-mongoid (0.2.4)
+      mongoid (>= 5.0)
+      shrine (~> 2.4)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -202,6 +216,7 @@ DEPENDENCIES
   carrierwave-mongoid
   ckeditor!
   dragonfly
+  image_processing
   jquery-rails (~> 4.3.3)
   mini_magick
   mongoid (~> 7.0.2)
@@ -211,6 +226,8 @@ DEPENDENCIES
   rails (= 5.2.2.1)
   rails-controller-testing
   sass
+  shrine
+  shrine-mongoid
   sqlite3 (~> 1.3.6)
 
 BUNDLED WITH

--- a/README.md
+++ b/README.md
@@ -347,6 +347,7 @@ $> rake test CKEDITOR_BACKEND=paperclip
 $> rake test CKEDITOR_BACKEND=active_storage
 $> rake test CKEDITOR_BACKEND=carrierwave
 $> rake test CKEDITOR_BACKEND=dragonfly
+$> rake test CKEDITOR_BACKEND=shrine
 $> rake test CKEDITOR_ORM=mongoid
 
 $> rake test:controllers

--- a/lib/ckeditor.rb
+++ b/lib/ckeditor.rb
@@ -28,6 +28,7 @@ module Ckeditor
     autoload :Paperclip, 'ckeditor/backend/paperclip'
     autoload :CarrierWave, 'ckeditor/backend/carrierwave'
     autoload :Dragonfly, 'ckeditor/backend/dragonfly'
+    autoload :Shrine, 'ckeditor/backend/shrine'
   end
 
   IMAGE_TYPES = %w[image/jpeg image/png image/gif image/jpg image/pjpeg image/tiff image/x-png].freeze

--- a/lib/ckeditor/backend/shrine.rb
+++ b/lib/ckeditor/backend/shrine.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Ckeditor
+  module Backend
+    module Shrine
+      def self.included(base)
+        base.send(:include, InstanceMethods)
+      end
+
+      module InstanceMethods
+        def url
+          data_url
+        end
+
+        def data_file_name
+          datasource['filename']
+        end
+
+        def data_file_size
+          datasource['size']
+        end
+
+        def datasource
+          @datasource ||= data&.metadata || {}
+        end
+      end
+    end
+  end
+end

--- a/lib/generators/ckeditor/install_generator.rb
+++ b/lib/generators/ckeditor/install_generator.rb
@@ -32,6 +32,10 @@ module Ckeditor
         if backend_dragonfly?
           template 'base/dragonfly/initializer.rb', 'config/initializers/ckeditor_dragonfly.rb'
         end
+
+        if backend_shrine?
+          template 'base/shrine/initializer.rb', 'config/initializers/ckeditor_shrine.rb'
+        end
       end
 
       def mount_engine
@@ -68,6 +72,10 @@ module Ckeditor
 
       def backend_dragonfly?
         backend == 'dragonfly'
+      end
+
+      def backend_shrine?
+        backend == 'shrine'
       end
 
       def ckeditor_dir

--- a/lib/generators/ckeditor/templates/base/shrine/initializer.rb
+++ b/lib/generators/ckeditor/templates/base/shrine/initializer.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'shrine'
+require 'shrine/storage/file_system'
+require 'ckeditor/backend/shrine'
+
+# Choose your favorite image processor
+require 'image_processing/mini_magick'
+SHRINE_PICTURE_PROCESSOR = ImageProcessing::MiniMagick
+
+# require 'image_processing/vips'
+# SHRINE_PICTURE_PROCESSOR = ImageProcessing::Vips
+
+Shrine.storages = {
+  cache: Shrine::Storage::FileSystem.new('public', prefix: 'uploads/cache'),
+  store: Shrine::Storage::FileSystem.new('public', prefix: 'system')
+}
+
+Shrine.plugin :determine_mime_type
+Shrine.plugin :mongoid
+Shrine.plugin :instrumentation
+
+Shrine.plugin :validation_helpers
+Shrine.plugin :processing
+Shrine.plugin :versions

--- a/lib/generators/ckeditor/templates/mongoid/shrine/ckeditor/asset.rb
+++ b/lib/generators/ckeditor/templates/mongoid/shrine/ckeditor/asset.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class Ckeditor::Asset
+  include Ckeditor::Orm::Mongoid::AssetBase
+  include Ckeditor::Backend::Shrine
+
+  field :data_data, type: Hash
+end

--- a/lib/generators/ckeditor/templates/mongoid/shrine/ckeditor/attachment_file.rb
+++ b/lib/generators/ckeditor/templates/mongoid/shrine/ckeditor/attachment_file.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Ckeditor
+  class AttachmentFileUploader < Shrine
+    plugin :validation_helpers
+
+    Attacher.validate do
+      validate_max_size 100.megabytes
+    end
+  end
+
+  class AttachmentFile < Ckeditor::Asset
+    include AttachmentFileUploader.attachment(:data)
+
+    validates :data, presence: true
+
+    def url_thumb
+      @url_thumb ||= Ckeditor::Utils.filethumb(filename)
+    end
+  end
+end

--- a/lib/generators/ckeditor/templates/mongoid/shrine/ckeditor/picture.rb
+++ b/lib/generators/ckeditor/templates/mongoid/shrine/ckeditor/picture.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+module Ckeditor
+  class PictureUploader < Shrine
+    plugin :determine_mime_type
+    plugin :validation_helpers
+    plugin :processing
+    plugin :versions
+
+    Attacher.validate do
+      validate_mime_type_inclusion %w[image/jpeg image/gif image/png]
+      validate_max_size 2.megabytes
+    end
+
+    process(:store) do |io, _context|
+      # return the hash of processed files
+      {}.tap do |versions|
+        io.download do |original|
+          pipeline = SHRINE_PICTURE_PROCESSOR.source(original)
+
+          versions[:content] = pipeline.resize_to_limit!(800, 800)
+          versions[:thumb] = pipeline.resize_to_limit!(118, 100)
+        end
+      end
+    end
+  end
+
+  class Picture < Ckeditor::Asset
+    include PictureUploader.attachment(:data)
+
+    validates :data, presence: true
+
+    def url_content
+      data_url(:content)
+    end
+
+    def url_thumb
+      data_url(:thumb)
+    end
+
+    def path
+      data[:thumb].storage.path(data[:thumb].id)
+    end
+
+    def datasource
+      @datasource ||= HashWithIndifferentAccess
+                      .new(data)
+                      .fetch(:thumb, OpenStruct.new(metadata: {}))
+                      .metadata
+    end
+  end
+end

--- a/test/models/picture_test.rb
+++ b/test/models/picture_test.rb
@@ -10,15 +10,19 @@ class PictureTest < ActiveSupport::TestCase
   test 'Set file content_type and size' do
     @picture = create_picture
 
-    assert_equal 'rails.png', @picture.data_file_name
-    assert_equal 6646, @picture.data_file_size
-
-    if CKEDITOR_BACKEND == :dragonfly
+    assert_equal 'rails.png', @picture.data_file_name unless CKEDITOR_BACKEND == :shrine
+    case CKEDITOR_BACKEND
+    when :dragonfly
       assert @picture.url_thumb.include?('thumb_rails')
-    elsif CKEDITOR_BACKEND == :active_storage
+    when :active_storage
       assert @picture.url_thumb =~ /\/representations\/.*\/rails.png/
+    when :shrine
+      assert @picture.url_thumb =~ /\S{32}\.png/
+      assert @picture.data_file_name =~ /image_processing(\d{8})-(\d{5})-(\S{,7})\.png/
     else
       assert @picture.url_thumb.include?('thumb_rails.png')
     end
+
+    assert_equal 6646, @picture.data_file_size
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,7 +7,7 @@ CKEDITOR_BACKEND = (ENV['CKEDITOR_BACKEND'] || :paperclip).to_sym
 
 $:.unshift File.dirname(__FILE__)
 puts "\n==> Ckeditor.orm = #{CKEDITOR_ORM.inspect}. CKEDITOR_ORM = (active_record|mongoid)"
-puts "\n==> Ckeditor.backend = #{CKEDITOR_BACKEND.inspect}. CKEDITOR_BACKEND = (paperclip|active_storage|carrierwave|dragonfly)"
+puts "\n==> Ckeditor.backend = #{CKEDITOR_BACKEND.inspect}. CKEDITOR_BACKEND = (shrine|paperclip|active_storage|carrierwave|dragonfly)"
 
 require File.expand_path('../dummy/config/environment.rb', __FILE__)
 require 'rails/test_help'


### PR DESCRIPTION
I've just added shrine backend to work with mongoid. I'm having a problem with size test on picture_test.rb that not matches with expected 6646 bytes.

I was digging into generated files:

* /system/picture.png has a different size
* /uploads/cache/picture.png has the expected size

I don't know why this different sizes but all the rest of tests work well
