### PR TITLE
fix: Change method name from extension_white_list to extension_whitelist

### DIFF
--- a/lib/generators/ckeditor/templates/base/carrierwave/uploaders/ckeditor_attachment_file_uploader.rb
+++ b/lib/generators/ckeditor/templates/base/carrierwave/uploaders/ckeditor_attachment_file_uploader.rb
@@ -33,7 +33,7 @@ class CkeditorAttachmentFileUploader < CarrierWave::Uploader::Base
 
   # Add a white list of extensions which are allowed to be uploaded.
   # For images you might use something like this:
-  def extension_white_list
+  def extension_whitelist
     Ckeditor.attachment_file_types
   end
 end

--- a/lib/generators/ckeditor/templates/base/carrierwave/uploaders/ckeditor_picture_uploader.rb
+++ b/lib/generators/ckeditor/templates/base/carrierwave/uploaders/ckeditor_picture_uploader.rb
@@ -40,7 +40,7 @@ class CkeditorPictureUploader < CarrierWave::Uploader::Base
 
   # Add a white list of extensions which are allowed to be uploaded.
   # For images you might use something like this:
-  def extension_white_list
+  def extension_whitelist
     Ckeditor.image_file_types
   end
 end


### PR DESCRIPTION
CarrierWave's `extension_white_list` has been renamed to` extension_whitelist`.

https://github.com/carrierwaveuploader/carrierwave/blob/master/CHANGELOG.md
https://github.com/carrierwaveuploader/carrierwave/pull/1819

Therefore, rename of the overridden methods.
