### PR TITLE
add shrine templates for ActiveRecord

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,14 @@ gem 'dragonfly'
 rails generate ckeditor:install --orm=active_record --backend=dragonfly
 ```
 
+#### ActiveRecord + shrine
+
+```
+gem 'shrine'
+
+rails generate ckeditor:install --orm=active_record --backend=shrine
+```
+
 #### Mongoid + paperclip
 
 ```

--- a/lib/generators/ckeditor/templates/active_record/shrine/ckeditor/asset.rb
+++ b/lib/generators/ckeditor/templates/active_record/shrine/ckeditor/asset.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class Ckeditor::Asset < ActiveRecord::Base
+  include Ckeditor::Orm::ActiveRecord::AssetBase
+  include Ckeditor::Backend::Shrine
+end

--- a/lib/generators/ckeditor/templates/active_record/shrine/ckeditor/attachment_file.rb
+++ b/lib/generators/ckeditor/templates/active_record/shrine/ckeditor/attachment_file.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Ckeditor
+  class AttachmentFileUploader < Shrine
+    plugin :validation_helpers
+
+    Attacher.validate do
+      validate_max_size 100.megabytes
+    end
+  end
+
+  class AttachmentFile < Ckeditor::Asset
+    include AttachmentFileUploader.attachment(:data)
+
+    validates :data, presence: true
+
+    def url_thumb
+      @url_thumb ||= Ckeditor::Utils.filethumb(filename)
+    end
+  end
+end

--- a/lib/generators/ckeditor/templates/active_record/shrine/ckeditor/picture.rb
+++ b/lib/generators/ckeditor/templates/active_record/shrine/ckeditor/picture.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module Ckeditor
+  class PictureUploader < Shrine
+    plugin :determine_mime_type
+    plugin :validation_helpers
+    plugin :processing
+    plugin :versions
+
+    Attacher.validate do
+      validate_mime_type_inclusion %w[image/jpeg image/gif image/png]
+      validate_max_size 2.megabytes
+    end
+
+    process(:store) do |io, _context|
+      # return the hash of processed files
+      {}.tap do |versions|
+        io.download do |original|
+          pipeline = SHRINE_PICTURE_PROCESSOR.source(original)
+
+          versions[:content] = pipeline.resize_to_limit!(800, 800)
+          versions[:thumb] = pipeline.resize_to_limit!(118, 100)
+        end
+      end
+    end
+  end
+
+  class Picture < Ckeditor::Asset
+    include PictureUploader.attachment(:data)
+
+    validates :data, presence: true
+
+    def url_content
+      data_url(:content)
+    end
+
+    def url_thumb
+      data_url(:thumb)
+    end
+
+    def path
+      data[:thumb].storage.path(data[:thumb].id)
+    end
+
+    def datasource
+      @datasource ||= HashWithIndifferentAccess
+                      .new(data)
+                      .fetch(:thumb, OpenStruct.new(metadata: {}))
+                      .metadata
+    end
+  end
+end

--- a/lib/generators/ckeditor/templates/active_record/shrine/ckeditor/picture.rb
+++ b/lib/generators/ckeditor/templates/active_record/shrine/ckeditor/picture.rb
@@ -14,8 +14,8 @@ module Ckeditor
     Attacher.derivatives_processor do |original|
       magick = SHRINE_PICTURE_PROCESSOR.source(original)
       {
-        content: magick.resize_to_limit(800, 800),
-        thumb:   magick.resize_to_limit(118, 100),
+        content: magick.resize_to_limit!(800, 800),
+        thumb:   magick.resize_to_limit!(118, 100),
       }
     end
   end

--- a/lib/generators/ckeditor/templates/active_record/shrine/migration.rb
+++ b/lib/generators/ckeditor/templates/active_record/shrine/migration.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class CreateCkeditorAssets < ActiveRecord::Migration[5.2]
+  def up
+    create_table :ckeditor_assets do |t|
+      t.text  :data_data
+      t.string  :type, limit: 30
+
+      t.timestamps null: false
+    end
+
+    add_index :ckeditor_assets, :type
+  end
+
+  def down
+    drop_table :ckeditor_assets
+  end
+end

--- a/lib/generators/ckeditor/templates/base/shrine/initializer.rb
+++ b/lib/generators/ckeditor/templates/base/shrine/initializer.rb
@@ -21,5 +21,11 @@ Shrine.plugin :activerecord
 Shrine.plugin :instrumentation
 
 Shrine.plugin :validation_helpers
-Shrine.plugin :processing
-Shrine.plugin :versions
+Shrine.plugin :derivatives, versions_compatibility: true
+
+class Shrine::Attacher
+  def promote(*)
+    create_derivatives
+    super
+  end
+end

--- a/lib/generators/ckeditor/templates/base/shrine/initializer.rb
+++ b/lib/generators/ckeditor/templates/base/shrine/initializer.rb
@@ -17,7 +17,7 @@ Shrine.storages = {
 }
 
 Shrine.plugin :determine_mime_type
-Shrine.plugin :mongoid
+Shrine.plugin :activerecord
 Shrine.plugin :instrumentation
 
 Shrine.plugin :validation_helpers


### PR DESCRIPTION
This is a first naive push at this addition. There are no added tests, the gem works and responds to the generate command: `rails generate ckeditor:install --orm=active_record --backend=shrine` by building the full set of files, which work in click-testing.