### PR TITLE
Stop extending ActiveSupport::Concern in the modules that do not use its feature

### DIFF
--- a/lib/ckeditor/helpers/controllers.rb
+++ b/lib/ckeditor/helpers/controllers.rb
@@ -3,8 +3,6 @@
 module Ckeditor
   module Helpers
     module Controllers
-      extend ActiveSupport::Concern
-
       protected
 
       def ckeditor_current_user

--- a/lib/ckeditor/helpers/form_builder.rb
+++ b/lib/ckeditor/helpers/form_builder.rb
@@ -3,8 +3,6 @@
 module Ckeditor
   module Helpers
     module FormBuilder
-      extend ActiveSupport::Concern
-
       def cktext_area(method, options = {})
         @template.cktext_area(@object_name, method, objectify_options(options))
       end

--- a/lib/ckeditor/helpers/form_helper.rb
+++ b/lib/ckeditor/helpers/form_helper.rb
@@ -3,8 +3,6 @@
 module Ckeditor
   module Helpers
     module FormHelper
-      extend ActiveSupport::Concern
-
       def cktext_area(object_name, method, options = {})
         TextArea.new(self, options).render_instance_tag(object_name, method)
       end

--- a/lib/ckeditor/helpers/view_helper.rb
+++ b/lib/ckeditor/helpers/view_helper.rb
@@ -3,8 +3,6 @@
 module Ckeditor
   module Helpers
     module ViewHelper
-      extend ActiveSupport::Concern
-
       def cktext_area_tag(name, content = nil, options = {})
         TextArea.new(self, options).render_tag(name, content)
       end


### PR DESCRIPTION
We can remove `extend AS::Concern` from the whole codebase since these modules do never use (have never used) any ActiveSupport::Concern feature.