### PR TITLE
Prefer ActionView::OutputBuffer over ActiveSupport::SafeBuffer as a buffer for views

### DIFF
--- a/lib/ckeditor/text_area.rb
+++ b/lib/ckeditor/text_area.rb
@@ -42,7 +42,7 @@ module Ckeditor
     end
 
     def output_buffer
-      @output_buffer ||= ActiveSupport::SafeBuffer.new
+      @output_buffer ||= ActionView::OutputBuffer.new
     end
 
     def build_tag(object_name, method)


### PR DESCRIPTION
Ckeditor instantiates ActiveSupport::SafeBuffer in TextArea, but we'd better use the dedicated buffer class for views in Action View where we're already depending on Action View.
https://github.com/rails/rails/blob/master/actionview/lib/action_view/buffers.rb