### PR TITLE
Add shrine templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Rails.application.config.assets.precompile += %w[ckeditor/config.js]
 For file upload support, you must generate the necessary file storage models.
 The currently supported backends are:
 
-* ActiveRecord (active_storage, paperclip, carrierwave, dragonfly)
+* ActiveRecord (active_storage, paperclip, carrierwave, dragonfly, shrine)
 * Mongoid (paperclip, carrierwave, dragonfly)
 
 ### How to generate models to store uploaded files
@@ -78,6 +78,13 @@ Requires Dragonfly 1.0 or higher.
 gem 'dragonfly'
 
 rails generate ckeditor:install --orm=active_record --backend=dragonfly
+```
+
+#### ActiveRecord + shrine
+
+```
+gem 'shrine'
+rails generate ckeditor:install --orm=active_record --backend=shrine
 ```
 
 #### Mongoid + paperclip

--- a/lib/generators/ckeditor/install_generator.rb
+++ b/lib/generators/ckeditor/install_generator.rb
@@ -15,7 +15,7 @@ module Ckeditor
                          desc: 'Backend processor for upload support'
 
       class_option :backend, type: :string, default: 'paperclip',
-                             desc: 'paperclip (default), active_storage, carrierwave or dragonfly'
+                             desc: 'paperclip (default), active_storage, carrierwave dragonfly or shrine'
 
       def self.source_root
         @source_root ||= File.expand_path(File.join(File.dirname(__FILE__), 'templates'))
@@ -48,13 +48,16 @@ module Ckeditor
                    File.join('app/models', ckeditor_dir, "#{filename}.rb")
         end
 
-        if backend_carrierwave?
-          template "#{uploaders_dir}/uploaders/ckeditor_attachment_file_uploader.rb",
-                   File.join('app/uploaders', 'ckeditor_attachment_file_uploader.rb')
+      end
 
-          template "#{uploaders_dir}/uploaders/ckeditor_picture_uploader.rb",
-                   File.join('app/uploaders', 'ckeditor_picture_uploader.rb')
-        end
+      def create_uploaders
+        return unless backend_carrierwave? || backend_shrine?
+
+        template "#{uploaders_dir}/uploaders/ckeditor_attachment_file_uploader.rb",
+                  File.join('app/uploaders', 'ckeditor_attachment_file_uploader.rb')
+
+        template "#{uploaders_dir}/uploaders/ckeditor_picture_uploader.rb",
+                  File.join('app/uploaders', 'ckeditor_picture_uploader.rb')
       end
 
       def create_ckeditor_migration
@@ -87,7 +90,11 @@ module Ckeditor
       end
 
       def uploaders_dir
-        @uploaders_dir ||= 'base/carrierwave'
+        @uploaders_dir ||= if backend_carrierwave?
+          'base/carrierwave'
+        else
+          generator_dir
+        end
       end
 
       def orm

--- a/lib/generators/ckeditor/templates/active_record/shrine/ckeditor/asset.rb
+++ b/lib/generators/ckeditor/templates/active_record/shrine/ckeditor/asset.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class Ckeditor::Asset < ActiveRecord::Base
+  include Ckeditor::Orm::ActiveRecord::AssetBase
+  include Ckeditor::Backend::Shrine
+end

--- a/lib/generators/ckeditor/templates/active_record/shrine/ckeditor/attachment_file.rb
+++ b/lib/generators/ckeditor/templates/active_record/shrine/ckeditor/attachment_file.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class Ckeditor::AttachmentFile < Ckeditor::Asset
+  include AttachmentFileUploader.attachment(:data)
+
+  validates :data, presence: true
+
+  def url_thumb
+    @url_thumb ||= Ckeditor::Utils.filethumb(filename)
+  end
+end

--- a/lib/generators/ckeditor/templates/active_record/shrine/ckeditor/picture.rb
+++ b/lib/generators/ckeditor/templates/active_record/shrine/ckeditor/picture.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class Ckeditor::Picture < Ckeditor::Asset
+  include PictureUploader.attachment(:data)
+
+  validates :data, presence: true
+
+  def url_content
+    data_url(:content)
+  end
+
+  def url_thumb
+    data_url(:thumb)
+  end
+
+  def path
+    data[:thumb].storage.path(data[:thumb].id)
+  end
+end

--- a/lib/generators/ckeditor/templates/active_record/shrine/migration.rb
+++ b/lib/generators/ckeditor/templates/active_record/shrine/migration.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class CreateCkeditorAssets < ActiveRecord::Migration[5.2]
+  def up
+    create_table :ckeditor_assets do |t|
+      t.text  :data_data
+      t.string  :type, limit: 30
+
+      t.timestamps null: false
+    end
+
+    add_index :ckeditor_assets, :type
+  end
+
+  def down
+    drop_table :ckeditor_assets
+  end
+end

--- a/lib/generators/ckeditor/templates/active_record/shrine/uploaders/ckeditor_attachment_file_uploader.rb
+++ b/lib/generators/ckeditor/templates/active_record/shrine/uploaders/ckeditor_attachment_file_uploader.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class CkeditorAttachmentFileUploader < Shrine
+  plugin :validation_helpers
+
+  Attacher.validate do
+    validate_max_size 100.megabytes
+  end
+end

--- a/lib/generators/ckeditor/templates/active_record/shrine/uploaders/ckeditor_picture_uploader.rb
+++ b/lib/generators/ckeditor/templates/active_record/shrine/uploaders/ckeditor_picture_uploader.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class CkeditorPictureUploader < Shrine
+  plugin :determine_mime_type
+  plugin :validation_helpers
+  plugin :derivatives, versions_compatibility: true
+
+  Attacher.validate do
+    validate_mime_type_inclusion %w[image/jpeg image/gif image/png]
+    validate_max_size 2.megabytes
+  end
+
+  Attacher.derivatives_processor do |original|
+    magick = SHRINE_PICTURE_PROCESSOR.source(original)
+    {
+      content: magick.resize_to_limit!(800, 800),
+      thumb:   magick.resize_to_limit!(118, 100),
+    }
+  end
+end

--- a/lib/generators/ckeditor/templates/base/shrine/initializer.rb
+++ b/lib/generators/ckeditor/templates/base/shrine/initializer.rb
@@ -17,9 +17,20 @@ Shrine.storages = {
 }
 
 Shrine.plugin :determine_mime_type
+Shrine.plugin :activerecord
 Shrine.plugin :mongoid
 Shrine.plugin :instrumentation
 
 Shrine.plugin :validation_helpers
 Shrine.plugin :processing
 Shrine.plugin :versions
+
+Shrine.plugin :validation_helpers
+Shrine.plugin :derivatives, versions_compatibility: true
+
+class Shrine::Attacher
+  def promote(*)
+    create_derivatives
+    super
+  end
+end

--- a/lib/generators/ckeditor/templates/mongoid/shrine/ckeditor/attachment_file.rb
+++ b/lib/generators/ckeditor/templates/mongoid/shrine/ckeditor/attachment_file.rb
@@ -1,16 +1,8 @@
 # frozen_string_literal: true
 
 module Ckeditor
-  class AttachmentFileUploader < Shrine
-    plugin :validation_helpers
-
-    Attacher.validate do
-      validate_max_size 100.megabytes
-    end
-  end
-
   class AttachmentFile < Ckeditor::Asset
-    include AttachmentFileUploader.attachment(:data)
+    include CkeditorAttachmentFileUploader.attachment(:data)
 
     validates :data, presence: true
 

--- a/lib/generators/ckeditor/templates/mongoid/shrine/ckeditor/picture.rb
+++ b/lib/generators/ckeditor/templates/mongoid/shrine/ckeditor/picture.rb
@@ -1,31 +1,7 @@
 # frozen_string_literal: true
 module Ckeditor
-  class PictureUploader < Shrine
-    plugin :determine_mime_type
-    plugin :validation_helpers
-    plugin :processing
-    plugin :versions
-
-    Attacher.validate do
-      validate_mime_type_inclusion %w[image/jpeg image/gif image/png]
-      validate_max_size 2.megabytes
-    end
-
-    process(:store) do |io, _context|
-      # return the hash of processed files
-      {}.tap do |versions|
-        io.download do |original|
-          pipeline = SHRINE_PICTURE_PROCESSOR.source(original)
-
-          versions[:content] = pipeline.resize_to_limit!(800, 800)
-          versions[:thumb] = pipeline.resize_to_limit!(118, 100)
-        end
-      end
-    end
-  end
-
   class Picture < Ckeditor::Asset
-    include PictureUploader.attachment(:data)
+    include CkeditorPictureUploader.attachment(:data)
 
     validates :data, presence: true
 

--- a/lib/generators/ckeditor/templates/mongoid/shrine/uploaders/ckeditor_attachment_file_uploader.rb
+++ b/lib/generators/ckeditor/templates/mongoid/shrine/uploaders/ckeditor_attachment_file_uploader.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class CkeditorAttachmentFileUploader < Shrine
+  plugin :validation_helpers
+
+  Attacher.validate do
+    validate_max_size 100.megabytes
+  end
+end

--- a/lib/generators/ckeditor/templates/mongoid/shrine/uploaders/ckeditor_picture_uploader.rb
+++ b/lib/generators/ckeditor/templates/mongoid/shrine/uploaders/ckeditor_picture_uploader.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class CkeditorPictureUploader < Shrine
+  plugin :determine_mime_type
+  plugin :validation_helpers
+  plugin :processing
+  plugin :versions
+
+  Attacher.validate do
+    validate_mime_type_inclusion %w[image/jpeg image/gif image/png]
+    validate_max_size 2.megabytes
+  end
+
+  process(:store) do |io, _context|
+    # return the hash of processed files
+    {}.tap do |versions|
+      io.download do |original|
+        pipeline = SHRINE_PICTURE_PROCESSOR.source(original)
+
+        versions[:content] = pipeline.resize_to_limit!(800, 800)
+        versions[:thumb] = pipeline.resize_to_limit!(118, 100)
+      end
+    end
+  end
+end

--- a/test/generators/install_generator_test.rb
+++ b/test/generators/install_generator_test.rb
@@ -88,6 +88,24 @@ class InstallGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  test 'models and migration for active_record orm via shrine' do
+    run_generator %w[--orm=active_record --backend=shrine]
+
+    assert_file 'app/models/ckeditor/asset.rb'
+    assert_file 'app/models/ckeditor/picture.rb'
+    assert_file 'app/models/ckeditor/attachment_file.rb'
+
+    assert_file 'app/uploaders/ckeditor_picture_uploader.rb'
+    assert_file 'app/uploaders/ckeditor_attachment_file_uploader.rb'
+
+    assert_migration 'db/migrate/create_ckeditor_assets.rb' do |migration|
+      assert_method :up, migration do |up|
+        assert_match /create_table/, up
+        assert_match /data_data/, up
+      end
+    end
+  end
+
   test 'models for mongoid orm via paperclip' do
     run_generator %w[--orm=mongoid --backend=paperclip]
 


### PR DESCRIPTION
Fixes the issue #934. Allows run command `rails generate ckeditor:install --orm=active_record --backend=shrine ` for creating models and uploaders